### PR TITLE
🎨 Palette: Improve Suggestion Item Accessibility

### DIFF
--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -49,9 +49,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({
             ${disabled ? 'opacity-50 pointer-events-none' : 'hover:border-action hover:bg-surface-highlight border-border-subtle'}
         `} >
             {/* Header / Action Area */}
-            < div
-                className="flex items-center gap-2 p-2 cursor-pointer"
+            <button
+                type="button"
+                className="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
                 onClick={onClick}
+                disabled={disabled}
             >
                 <div className={`
                     p-1.5 rounded-md shrink-0
@@ -75,7 +77,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({
                     </span>
                     {!isLoading && <ArrowRight className="w-3.5 h-3.5" />}
                 </div>
-            </div >
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,8 +9,9 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
-      class="flex items-center gap-2 p-2 cursor-pointer"
+    <button
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
+      type="button"
     >
       <div
         class="
@@ -94,7 +95,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -140,8 +141,10 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
-      class="flex items-center gap-2 p-2 cursor-pointer"
+    <button
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -225,7 +228,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -271,8 +274,9 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
-      class="flex items-center gap-2 p-2 cursor-pointer"
+    <button
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
+      type="button"
     >
       <div
         class="
@@ -325,7 +329,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -12,8 +12,9 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
-        class="flex items-center gap-2 p-2 cursor-pointer"
+      <button
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
+        type="button"
       >
         <div
           class="
@@ -98,7 +99,7 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >
@@ -183,8 +184,9 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
-        class="flex items-center gap-2 p-2 cursor-pointer"
+      <button
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-action focus-visible:outline-none rounded-md"
+        type="button"
       >
         <div
           class="
@@ -280,7 +282,7 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >


### PR DESCRIPTION
💡 What: Converted the `SuggestionItem` interactive card from a `div` to a `<button>`.
🎯 Why: To ensure keyboard users can tab to and activate suggestions, and screen readers correctly identify the element as interactive.
♿ Accessibility:
- Added `type='button'` for semantics.
- Added `focus-visible` styles for clear focus indication.
- Mapped `disabled` state to the native button attribute.

---
*PR created automatically by Jules for task [15788752854867539332](https://jules.google.com/task/15788752854867539332) started by @lingyv-li*