### PR TITLE
Refactor Duplicate Cleaner Autopilot Check

### DIFF
--- a/src/background/tabManager.ts
+++ b/src/background/tabManager.ts
@@ -98,7 +98,7 @@ export class TabManager {
     async handleTabUpdated(tabId: number, changeInfo: { url?: string; status?: string; groupId?: number }) {
         // Autopilot: close duplicates when a tab navigates or finishes loading
         if (changeInfo.url || changeInfo.status === 'complete') {
-            // Check global autopilot setting for Tab Grouper
+            // Check global autopilot setting for Duplicate Cleaner
             const autopilotEnabled = await DuplicateCloser.isAutopilotEnabled();
 
             if (autopilotEnabled) {


### PR DESCRIPTION
The task was to encapsulate the duplicate cleaner autopilot check. The check was already encapsulated in `DuplicateCloser.isAutopilotEnabled()`, but the comment in `src/background/tabManager.ts` was incorrect (copy-paste error referring to Tab Grouper). This PR fixes the comment and verifies the implementation. Existing tests passed and build succeeded.

---
*PR created automatically by Jules for task [14574780791513294072](https://jules.google.com/task/14574780791513294072) started by @lingyv-li*