### PR TITLE
🎨 Palette: Use native button for suggestions

### DIFF
--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,13 +33,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
         <div
             className={`
@@ -49,12 +42,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+            <button
+                type='button'
+                disabled={disabled || isLoading}
+                className='w-full text-left flex items-center gap-2 p-2 cursor-pointer'
                 onClick={onClick}
-                onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
                 <div
@@ -83,7 +75,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     </span>
                     {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
                 </div>
-            </div>
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -42,7 +42,7 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
     });
 

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer"
+      type="button"
     >
       <div
         class="
@@ -97,7 +96,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -143,11 +142,11 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -231,7 +230,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -277,11 +276,11 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -334,7 +333,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -12,11 +12,10 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
+      <button
         aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer"
+        type="button"
       >
         <div
           class="
@@ -101,7 +100,7 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >
@@ -186,11 +185,10 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
+      <button
         aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer"
+        type="button"
       >
         <div
           class="
@@ -286,7 +284,7 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >


### PR DESCRIPTION
🎨 Palette: Use native button for suggestions

💡 What: Refactored `SuggestionItem` to use a native `<button>` element instead of a `div` with `role="button"`.
🎯 Why: Native buttons provide built-in accessibility features (focus management, keyboard support for Enter/Space, disabled state) and reduce the need for manual event handling, making the UI more robust and accessible for screen reader and keyboard users.
♿ Accessibility:
- Implicit ARIA role `button`.
- Native keyboard activation (Enter/Space).
- Native `disabled` attribute support.
- Native focus management (removed manual `tabIndex`).

---
*PR created automatically by Jules for task [14913224512083722387](https://jules.google.com/task/14913224512083722387) started by @lingyv-li*