### PR TITLE
🎨 Palette: Add focus indicators to interactive elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-30 - Focus Indicators
+**Learning:** Custom interactive elements (like `div` with `role="button"`) and standard buttons in this project lacked `focus-visible` styles, making keyboard navigation invisible.
+**Action:** Always add `focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none` to interactive elements.

--- a/src/sidepanel/components/ConfigurationSection.tsx
+++ b/src/sidepanel/components/ConfigurationSection.tsx
@@ -45,7 +45,7 @@ export const ConfigurationSection: React.FC = () => {
                         type='button'
                         onClick={() => toggleFeature(id, 'enabled')}
                         className={`
-                            p-1.5 rounded-md transition-all
+                            p-1.5 rounded-md transition-all focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-1
                             ${isEnabled ? 'bg-btn-primary-bg text-btn-primary-fg hover:bg-btn-primary-hover' : 'bg-surface-dim text-muted hover:text-main'}
                         `}
                         title={isEnabled ? 'Disable Feature' : 'Enable Feature'}
@@ -60,7 +60,7 @@ export const ConfigurationSection: React.FC = () => {
                         onClick={() => toggleFeature(id, 'autopilot')}
                         disabled={!isEnabled}
                         className={`
-                            p-1.5 rounded-md transition-all border
+                            p-1.5 rounded-md transition-all border focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-1
                             ${!isEnabled ? 'opacity-30 cursor-not-allowed border-transparent' : ''}
                             ${isAutopilot && isEnabled ? 'bg-status-ai-bg text-status-ai-fg border-status-ai-fg/20' : 'bg-surface-dim text-muted hover:text-main border-transparent'}
                         `}

--- a/src/sidepanel/components/ConfirmationModal.tsx
+++ b/src/sidepanel/components/ConfirmationModal.tsx
@@ -35,11 +35,14 @@ export const ConfirmationModal = ({ isOpen, onClose, onConfirm, title, descripti
                                 onConfirm();
                                 onClose();
                             }}
-                            className='w-full py-2.5 px-4 text-xs font-bold text-white bg-gradient-to-r from-amber-500 to-orange-500 hover:brightness-110 active:scale-[0.98] rounded-xl shadow-lg shadow-amber-500/20 transition-all flex items-center justify-center gap-2'
+                            className='w-full py-2.5 px-4 text-xs font-bold text-white bg-gradient-to-r from-amber-500 to-orange-500 hover:brightness-110 active:scale-[0.98] rounded-xl shadow-lg shadow-amber-500/20 transition-all flex items-center justify-center gap-2 focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-2'
                         >
                             <span>{confirmLabel}</span>
                         </button>
-                        <button onClick={onClose} className='w-full py-2.5 px-4 text-xs font-medium text-muted hover:text-main hover:bg-surface-highlight rounded-xl transition-colors'>
+                        <button
+                            onClick={onClose}
+                            className='w-full py-2.5 px-4 text-xs font-medium text-muted hover:text-main hover:bg-surface-highlight rounded-xl transition-colors focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-2'
+                        >
                             Cancel
                         </button>
                     </div>

--- a/src/sidepanel/components/Dashboard.tsx
+++ b/src/sidepanel/components/Dashboard.tsx
@@ -56,7 +56,7 @@ export const Dashboard = () => {
                 <p className='text-muted mb-8 max-w-[280px]'>To get started, we need to set up your AI preferences.</p>
                 <button
                     onClick={() => chrome.tabs.create({ url: chrome.runtime.getURL('src/welcome/index.html') })}
-                    className='w-full max-w-[280px] py-3 bg-gradient-brand text-inverted font-bold rounded-xl shadow-lg hover:brightness-110 active:scale-95 transition-all'
+                    className='w-full max-w-[280px] py-3 bg-gradient-brand text-inverted font-bold rounded-xl shadow-lg hover:brightness-110 active:scale-95 transition-all focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-2'
                 >
                     Start Setup
                 </button>

--- a/src/sidepanel/components/Header.tsx
+++ b/src/sidepanel/components/Header.tsx
@@ -27,7 +27,7 @@ export const Header = ({ isLoading }: HeaderProps) => {
                         type='button'
                         onClick={undoLast}
                         disabled={isUndoing}
-                        className='flex items-center justify-center p-2 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all border border-border-subtle'
+                        className='flex items-center justify-center p-2 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all border border-border-subtle focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none'
                         title='Undo last action'
                         aria-label='Undo last action'
                     >
@@ -36,8 +36,9 @@ export const Header = ({ isLoading }: HeaderProps) => {
                 )}
                 <button
                     onClick={() => chrome.runtime.openOptionsPage()}
-                    className='flex items-center gap-2 p-2 px-3 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all duration-200 cursor-pointer'
+                    className='flex items-center gap-2 p-2 px-3 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all duration-200 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none'
                     title='Options'
+                    aria-label='Options'
                 >
                     <Settings className='w-4 h-4' />
                 </button>

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -52,7 +52,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
             <div
                 role='button'
                 tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+                className='flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none'
                 onClick={onClick}
                 onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}

--- a/src/sidepanel/components/SuggestionList.tsx
+++ b/src/sidepanel/components/SuggestionList.tsx
@@ -123,7 +123,7 @@ export const SuggestionList: React.FC = () => {
                 <button
                     onClick={handleAcceptAll}
                     disabled={isAcceptingAll || processingId !== null}
-                    className='w-full py-2 px-4 bg-btn-primary-bg text-btn-primary-fg font-medium rounded-lg hover:bg-btn-primary-hover active:scale-95 transition-all text-sm shadow-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 mb-2'
+                    className='w-full py-2 px-4 bg-btn-primary-bg text-btn-primary-fg font-medium rounded-lg hover:bg-btn-primary-hover active:scale-95 transition-all text-sm shadow-sm disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 mb-2 focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-offset-2'
                 >
                     {isAcceptingAll ? <Loader2 className='w-4 h-4 animate-spin' /> : <Sparkles className='w-4 h-4' />}
                     <span>Accept All ({suggestions.length})</span>

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
   >
     <div
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
+      class="flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none"
       role="button"
       tabindex="0"
     >
@@ -145,7 +145,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
   >
     <div
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
+      class="flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none"
       role="button"
       tabindex="-1"
     >
@@ -279,7 +279,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
   >
     <div
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
+      class="flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none"
       role="button"
       tabindex="-1"
     >

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
     >
       <div
         aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
+        class="flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none"
         role="button"
         tabindex="0"
       >
@@ -188,7 +188,7 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
     >
       <div
         aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
+        class="flex items-center gap-2 p-2 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none"
         role="button"
         tabindex="0"
       >


### PR DESCRIPTION
💡 **What:** Added `focus-visible` styles (rings) to all primary interactive elements in the sidepanel.
🎯 **Why:** Keyboard users had no visual feedback when navigating the interface, making it difficult to use without a mouse.
📸 **Before/After:** Interactive elements now show a brand-colored ring when focused via keyboard.
♿ **Accessibility:** significantly improves WCAG compliance for focus visibility.

---
*PR created automatically by Jules for task [14975199203148329766](https://jules.google.com/task/14975199203148329766) started by @lingyv-li*