### PR TITLE
⚡ Bolt: Optimize SuggestionList rendering with React.memo and stable callbacks

### DIFF
--- a/src/hooks/useTabGrouper.ts
+++ b/src/hooks/useTabGrouper.ts
@@ -220,7 +220,7 @@ export const useTabGrouper = () => {
         };
     }, [currentWindowId, processSuggestionsRef]); // processSuggestions NOT a dependency - accessed via ref
 
-    const applyGroups = async () => {
+    const applyGroups = useCallback(async () => {
         if (!previewGroups) return;
         setInteractionStatus(OrganizerStatus.Applying);
         setError(null);
@@ -253,46 +253,53 @@ export const useTabGrouper = () => {
             setError(err instanceof Error ? err.message : String(err) || 'Failed to apply groups.');
             setInteractionStatus(OrganizerStatus.Idle);
         }
-    };
-    const applyGroup = async (index: number) => {
-        if (!previewGroups || !previewGroups[index]) return;
-        setInteractionStatus(OrganizerStatus.Applying);
-        setError(null);
+    }, [previewGroups, selectedPreviewIndices, snapshot]);
 
-        try {
-            const currentWindow = await chrome.windows.getCurrent();
-            const group = previewGroups[index];
+    const applyGroup = useCallback(
+        async (index: number) => {
+            if (!previewGroups || !previewGroups[index]) return;
+            setInteractionStatus(OrganizerStatus.Applying);
+            setError(null);
 
-            if (group.tabIds.length > 0) {
-                const validTabIds = group.tabIds.filter(id => snapshot?.hasTab(id));
+            try {
+                const currentWindow = await chrome.windows.getCurrent();
+                const group = previewGroups[index];
 
-                if (validTabIds.length > 0) {
-                    await applyTabGroup(validTabIds, group.groupName, group.existingGroupId, currentWindow.id!);
-                    await StateService.pushGroupAction({
-                        windowId: currentWindow.id!,
-                        tabIds: validTabIds,
-                        groupName: group.groupName,
-                        existingGroupId: group.existingGroupId
-                    });
+                if (group.tabIds.length > 0) {
+                    const validTabIds = group.tabIds.filter(id => snapshot?.hasTab(id));
+
+                    if (validTabIds.length > 0) {
+                        await applyTabGroup(validTabIds, group.groupName, group.existingGroupId, currentWindow.id!);
+                        await StateService.pushGroupAction({
+                            windowId: currentWindow.id!,
+                            tabIds: validTabIds,
+                            groupName: group.groupName,
+                            existingGroupId: group.existingGroupId
+                        });
+                    }
                 }
+                setInteractionStatus(OrganizerStatus.Success);
+                // We rely on background update to refresh suggestions
+                setTimeout(() => setInteractionStatus(OrganizerStatus.Idle), 1000);
+            } catch (err: unknown) {
+                setError(err instanceof Error ? err.message : String(err) || 'Failed to apply group.');
+                setInteractionStatus(OrganizerStatus.Idle);
             }
-            setInteractionStatus(OrganizerStatus.Success);
-            // We rely on background update to refresh suggestions
-            setTimeout(() => setInteractionStatus(OrganizerStatus.Idle), 1000);
-        } catch (err: unknown) {
-            setError(err instanceof Error ? err.message : String(err) || 'Failed to apply group.');
-            setInteractionStatus(OrganizerStatus.Idle);
-        }
-    };
-    const toggleGroupSelection = (idx: number) => {
-        const newSet = new Set(selectedPreviewIndices);
-        if (newSet.has(idx)) {
-            newSet.delete(idx);
-        } else {
-            newSet.add(idx);
-        }
-        setSelectedPreviewIndices(newSet);
-    };
+        },
+        [previewGroups, snapshot]
+    );
+
+    const toggleGroupSelection = useCallback((idx: number) => {
+        setSelectedPreviewIndices(prev => {
+            const newSet = new Set(prev);
+            if (newSet.has(idx)) {
+                newSet.delete(idx);
+            } else {
+                newSet.add(idx);
+            }
+            return newSet;
+        });
+    }, []);
 
     const regenerateSuggestions = useCallback(() => {
         if (!portRef.current || !currentWindowId) return;
@@ -315,14 +322,17 @@ export const useTabGrouper = () => {
         setBackgroundProcessing(true); // Show analyzing state immediately
     }, [currentWindowId]);
 
-    const setAllGroupsSelected = (selected: boolean) => {
-        if (!previewGroups) return;
-        if (selected) {
-            setSelectedPreviewIndices(new Set(previewGroups.map((_, i) => i)));
-        } else {
-            setSelectedPreviewIndices(new Set());
-        }
-    };
+    const setAllGroupsSelected = useCallback(
+        (selected: boolean) => {
+            if (!previewGroups) return;
+            if (selected) {
+                setSelectedPreviewIndices(new Set(previewGroups.map((_, i) => i)));
+            } else {
+                setSelectedPreviewIndices(new Set());
+            }
+        },
+        [previewGroups]
+    );
 
     // Suggestions from background (cache) as Action[] for UI
     const suggestionActions: Action[] = useMemo(() => {

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -3,17 +3,30 @@ import { LucideIcon, ArrowRight, Loader2 } from 'lucide-react';
 import { SuggestionType, SuggestionTab } from '../../types/suggestions';
 
 interface SuggestionItemProps {
+    id: string;
     title: string;
     description: string;
     icon: LucideIcon;
     type: SuggestionType;
-    onClick: () => void;
+    onAction: (id: string, action: () => Promise<void>) => void;
+    action: () => Promise<void>;
     isLoading?: boolean;
     disabled?: boolean;
     tabs?: SuggestionTab[];
 }
 
-export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, description, icon: Icon, type, onClick, isLoading, disabled, tabs }) => {
+function SuggestionItemBase({
+    id,
+    title,
+    description,
+    icon: Icon,
+    type,
+    onAction,
+    action,
+    isLoading,
+    disabled,
+    tabs
+}: SuggestionItemProps) {
     // Aggregate identical tabs
     const groupedTabs = React.useMemo(() => {
         if (!tabs) return [];
@@ -36,7 +49,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
     const handleKeyDown = (e: React.KeyboardEvent) => {
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            if (!disabled && !isLoading) onClick();
+            if (!disabled && !isLoading) onAction(id, action);
         }
     };
 
@@ -53,7 +66,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                 role='button'
                 tabIndex={disabled || isLoading ? -1 : 0}
                 className='flex items-center gap-2 p-2 cursor-pointer'
-                onClick={onClick}
+                onClick={() => onAction(id, action)}
                 onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
@@ -103,4 +116,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
             )}
         </div>
     );
-};
+}
+
+export const SuggestionItem = React.memo(SuggestionItemBase);

--- a/src/sidepanel/components/SuggestionList.tsx
+++ b/src/sidepanel/components/SuggestionList.tsx
@@ -1,9 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { Group, Trash2, Sparkles, Loader2, LucideIcon } from 'lucide-react';
 import { useTabGrouper } from '../../hooks/useTabGrouper';
 import { useDuplicateCleaner } from '../../hooks/useDuplicateCleaner';
 import { SuggestionItem } from './SuggestionItem';
-import { SuggestionType } from '../../types/suggestions';
+import { SuggestionType, SuggestionTab } from '../../types/suggestions';
 
 interface UnifiedSuggestion {
     id: string;
@@ -12,7 +12,7 @@ interface UnifiedSuggestion {
     description: string;
     icon: LucideIcon;
     onClick: () => Promise<void>;
-    tabs: chrome.tabs.Tab[];
+    tabs: SuggestionTab[];
 }
 
 export const SuggestionList: React.FC = () => {
@@ -21,15 +21,18 @@ export const SuggestionList: React.FC = () => {
     const [processingId, setProcessingId] = React.useState<string | null>(null);
     const [isAcceptingAll, setIsAcceptingAll] = React.useState(false);
 
-    const handleAction = async (id: string, action: () => Promise<void>) => {
-        if (processingId || isAcceptingAll) return;
-        setProcessingId(id);
-        try {
-            await action();
-        } finally {
-            setProcessingId(null);
-        }
-    };
+    const handleAction = useCallback(
+        async (id: string, action: () => Promise<void>) => {
+            if (processingId || isAcceptingAll) return;
+            setProcessingId(id);
+            try {
+                await action();
+            } finally {
+                setProcessingId(null);
+            }
+        },
+        [processingId, isAcceptingAll]
+    );
 
     // Build suggestions from Action[] (group + deduplicate) from background/UI
     const suggestions = useMemo(() => {
@@ -46,7 +49,7 @@ export const SuggestionList: React.FC = () => {
                 description: `Organize ${tabCount} tab${tabCount > 1 ? 's' : ''}`,
                 icon: Group,
                 onClick: () => applyGroup(index),
-                tabs: groupTabs
+                tabs: groupTabs.map(t => ({ title: t.title, url: t.url, favIconUrl: t.favIconUrl }))
             });
         });
 
@@ -64,7 +67,7 @@ export const SuggestionList: React.FC = () => {
                 description: `Close ${countToRemove} duplicate tab${countToRemove > 1 ? 's' : ''}`,
                 icon: Trash2,
                 onClick: () => closeDuplicateGroup(action.url),
-                tabs: duplicateTabs
+                tabs: duplicateTabs.map(t => ({ title: t.title, url: t.url, favIconUrl: t.favIconUrl }))
             });
         });
 
@@ -133,18 +136,16 @@ export const SuggestionList: React.FC = () => {
             {suggestions.map(item => (
                 <SuggestionItem
                     key={item.id}
+                    id={item.id}
                     title={item.title}
                     description={item.description}
                     icon={item.icon}
                     type={item.type}
-                    onClick={() => handleAction(item.id, item.onClick)}
+                    onAction={handleAction}
+                    action={item.onClick}
                     isLoading={processingId === item.id}
                     disabled={(processingId !== null && processingId !== item.id) || isAcceptingAll}
-                    tabs={item.tabs.map(t => ({
-                        title: t.title,
-                        url: t.url,
-                        favIconUrl: t.favIconUrl
-                    }))}
+                    tabs={item.tabs}
                 />
             ))}
         </div>

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -5,12 +5,17 @@ import { SuggestionType } from '../../../types/suggestions';
 import { Sparkles } from 'lucide-react';
 
 describe('SuggestionItem', () => {
+    const mockAction = vi.fn().mockResolvedValue(undefined);
+    const mockOnAction = vi.fn();
+
     const defaultProps = {
+        id: 'test-suggestion-id',
         title: 'Test Suggestion',
         description: 'Test Description',
         icon: Sparkles,
         type: SuggestionType.Group,
-        onClick: vi.fn(),
+        onAction: mockOnAction,
+        action: mockAction,
         tabs: [
             {
                 title: 'Tab 1',
@@ -42,8 +47,9 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
-        expect(defaultProps.onClick).toHaveBeenCalled();
+        // Click the main container which has role='button'
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
+        expect(mockOnAction).toHaveBeenCalledWith(defaultProps.id, mockAction);
     });
 
     it('groups identical tabs visually', () => {


### PR DESCRIPTION
⚡ Bolt: Optimized SuggestionList rendering

💡 What:
- Implemented `React.memo` for `SuggestionItem` to prevent re-renders when parent `SuggestionList` updates but item data hasn't changed.
- Stabilized `onClick` handlers and `tabs` props passed to `SuggestionItem` by wrapping action functions in `useCallback` (in hooks and component) and mapping tabs inside `useMemo`.
- Refactored `SuggestionItem` to accept `onAction` and `id` instead of a closure-based `onClick`.

🎯 Why:
- The `SuggestionList` re-renders frequently (e.g., when background processing status changes). Previously, this caused all `SuggestionItem` components to re-render because `onClick` and `tabs` props were new references on every render.
- This optimization ensures `SuggestionItem` only re-renders when its specific data or state changes.

📊 Impact:
- Reduces re-renders of `SuggestionItem` significantly during background processing updates.
- Improves UI responsiveness when managing many suggestions.

🔬 Measurement:
- Verified with `npm test`.
- Manually verified code logic ensures referential stability of props.

---
*PR created automatically by Jules for task [8592873030576175058](https://jules.google.com/task/8592873030576175058) started by @lingyv-li*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a rendering/performance refactor, but it changes callback identities and hook dependency behavior, which could introduce stale-state bugs if dependencies are incomplete.
> 
> **Overview**
> Improves sidepanel suggestion rendering performance by wrapping `SuggestionItem` in `React.memo` and refactoring it to accept `id`, `action`, and a shared `onAction` handler instead of per-item `onClick` closures.
> 
> Stabilizes callbacks in `useTabGrouper` and `useDuplicateCleaner` (e.g., `applyGroups`, `applyGroup`, `closeDuplicates`, `closeDuplicateGroup`, selection helpers) and normalizes `tabs` props to lightweight `SuggestionTab` objects created inside the suggestions `useMemo`. Updates the `SuggestionItem` tests to match the new props and click behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a22d065087e4dd910b794de82cf44acdb8044ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->