### PR TITLE
🎨 Palette: Semantic Button for SuggestionItem

### DIFF
--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,30 +33,21 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
-        <div
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled || isLoading}
+            aria-busy={isLoading}
+            aria-label={`${title}: ${description}. Apply suggestion.`}
             className={`
-            w-full group relative overflow-hidden
+            w-full group relative overflow-hidden text-left cursor-pointer
             bg-surface border rounded-lg transition-all duration-200
             ${disabled ? 'opacity-50 pointer-events-none' : 'hover:border-action hover:bg-surface-highlight border-border-subtle'}
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
-                onClick={onClick}
-                onKeyDown={handleKeyDown}
-                aria-label={`${title}: ${description}. Apply suggestion.`}
-            >
+            <div className='flex items-center gap-2 p-2'>
                 <div
                     className={`
                     p-1.5 rounded-md shrink-0
@@ -101,6 +92,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     ))}
                 </div>
             )}
-        </div>
+        </button>
     );
 };

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -42,7 +42,7 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
     });
 

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -2,18 +2,17 @@
 
 exports[`SuggestionItem > renders correctly 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full group relative overflow-hidden text-left cursor-pointer
             bg-surface border rounded-lg transition-all duration-200
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -130,24 +129,24 @@ exports[`SuggestionItem > renders correctly 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;
 
 exports[`SuggestionItem > renders disabled state 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full group relative overflow-hidden text-left cursor-pointer
             bg-surface border rounded-lg transition-all duration-200
             opacity-50 pointer-events-none
         "
+    disabled=""
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -264,24 +263,25 @@ exports[`SuggestionItem > renders disabled state 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;
 
 exports[`SuggestionItem > renders loading state 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-busy="true"
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full group relative overflow-hidden text-left cursor-pointer
             bg-surface border rounded-lg transition-all duration-200
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+    disabled=""
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -367,6 +367,6 @@ exports[`SuggestionItem > renders loading state 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;


### PR DESCRIPTION
🎨 Palette: Improved SuggestionItem Accessibility

💡 **What:** Refactored the `SuggestionItem` component to use a semantic `<button>` element instead of a `div` with `role="button"`.

🎯 **Why:**
- **Accessibility:** Native buttons provide built-in keyboard support (Enter/Space) and focus management without custom handlers.
- **Usability:** The entire card is now the click target, not just the header, making it easier to interact with.
- **Standardization:** Using semantic HTML is a best practice.

📸 **Before/After:**
- Visually identical (verified via Playwright).
- Dom structure simplified (removed manual key handlers).

♿ **Accessibility:**
- Added `aria-busy` for loading states.
- Ensured `disabled` attribute is used natively.
- Interactive elements are now correctly identified as buttons by screen readers.

---
*PR created automatically by Jules for task [8588134849442741947](https://jules.google.com/task/8588134849442741947) started by @lingyv-li*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI semantics change that mainly affects DOM structure, click target, and accessibility attributes; potential risk is minor styling/interaction regressions due to the wrapper element change.
> 
> **Overview**
> **Improves `SuggestionItem` accessibility and interaction** by replacing the outer clickable `div`/`role="button"` + custom key handling with a real `<button>` that wraps the whole card.
> 
> The component now uses native `disabled` behavior (including during `isLoading`) and adds `aria-busy`, and the unit test click selector and snapshots are updated to match the new button-based DOM.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5da5e9fd437f116997ac9d3501aad8906464b067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->