### PR TITLE
🎨 Palette: Semantic buttons for SuggestionItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Semantic Buttons for Interactive Cards
+**Learning:** Refactoring `div role='button'` cards to semantic `<button>` elements simplified code by removing manual key handlers and improved accessibility by providing native focus/disabled states. Tailwind requires explicit `w-full text-left` to maintain card layout.
+**Action:** Default to `<button>` for any interactive container, ensuring CSS resets are applied.

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,13 +33,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
         <div
             className={`
@@ -49,12 +42,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+            <button
+                type='button'
+                disabled={disabled || isLoading}
+                className='w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset'
                 onClick={onClick}
-                onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
                 <div
@@ -83,7 +75,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     </span>
                     {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
                 </div>
-            </div>
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -42,7 +42,7 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
     });
 

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      type="button"
     >
       <div
         class="
@@ -97,7 +96,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -143,11 +142,11 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -231,7 +230,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -277,11 +276,11 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -334,7 +333,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >


### PR DESCRIPTION
💡 What: Refactored SuggestionItem to use a semantic <button> instead of a div with role="button".
🎯 Why: Using native buttons improves accessibility by handling keyboard interactions (Enter/Space) and focus states automatically, while reducing custom event handling code.
♿ Accessibility: Added focus-visible styles, proper disabled state, and removed manual key handlers.
📸 Before/After: Visuals remain identical (verified via Playwright), but underlying markup is now semantically correct.

---
*PR created automatically by Jules for task [2532906433907134583](https://jules.google.com/task/2532906433907134583) started by @lingyv-li*