### PR TITLE
🎨 Palette: Use semantic button for SuggestionItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-05 - Semantic Buttons for Interactive Cards
+**Learning:** Replacing `div` with `role="button"` with native `<button>` elements simplifies accessibility implementation (keyboard handling, focus) but requires careful CSS resets (text alignment, width) to maintain layout.
+**Action:** Default to `<button type="button" className="w-full text-left">` for card-like interactive elements instead of divs.

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,30 +33,21 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
-        <div
+        <button
+            type='button'
+            disabled={disabled || isLoading}
+            onClick={onClick}
+            aria-label={`${title}: ${description}. Apply suggestion.`}
             className={`
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
-            ${disabled ? 'opacity-50 pointer-events-none' : 'hover:border-action hover:bg-surface-highlight border-border-subtle'}
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
+            ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:border-action hover:bg-surface-highlight border-border-subtle'}
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
-                onClick={onClick}
-                onKeyDown={handleKeyDown}
-                aria-label={`${title}: ${description}. Apply suggestion.`}
-            >
+            <div className='flex items-center gap-2 p-2'>
                 <div
                     className={`
                     p-1.5 rounded-md shrink-0
@@ -101,6 +92,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     ))}
                 </div>
             )}
-        </div>
+        </button>
     );
 };

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -42,8 +42,13 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
+    });
+
+    it('is disabled when disabled prop is true', () => {
+        render(<SuggestionItem {...defaultProps} disabled={true} />);
+        expect(screen.getByRole('button', { name: /Test Suggestion/i })).toBeDisabled();
     });
 
     it('groups identical tabs visually', () => {

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -2,18 +2,18 @@
 
 exports[`SuggestionItem > renders correctly 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -130,24 +130,25 @@ exports[`SuggestionItem > renders correctly 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;
 
 exports[`SuggestionItem > renders disabled state 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
-            opacity-50 pointer-events-none
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
+            opacity-50 cursor-not-allowed
         "
+    disabled=""
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -264,24 +265,25 @@ exports[`SuggestionItem > renders disabled state 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;
 
 exports[`SuggestionItem > renders loading state 1`] = `
 <DocumentFragment>
-  <div
+  <button
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+    disabled=""
+    type="button"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
         class="
@@ -367,6 +369,6 @@ exports[`SuggestionItem > renders loading state 1`] = `
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </DocumentFragment>
 `;

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -5,18 +5,18 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
   <div
     class="flex flex-col gap-2 p-3"
   >
-    <div
+    <button
+      aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
       class="
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+      type="button"
     >
       <div
-        aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="flex items-center gap-2 p-2"
       >
         <div
           class="
@@ -118,7 +118,7 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
           </span>
         </div>
       </div>
-    </div>
+    </button>
   </div>
 </DocumentFragment>
 `;
@@ -179,18 +179,18 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
   <div
     class="flex flex-col gap-2 p-3"
   >
-    <div
+    <button
+      aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
       class="
-            w-full group relative overflow-hidden
+            w-full text-left cursor-pointer group relative overflow-hidden
             bg-surface border rounded-lg transition-all duration-200
+            focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
+      type="button"
     >
       <div
-        aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="flex items-center gap-2 p-2"
       >
         <div
           class="
@@ -315,7 +315,7 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
           </span>
         </div>
       </div>
-    </div>
+    </button>
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
Refactored `SuggestionItem` to use a semantic `<button>` element instead of a `div` with `role="button"`. This improves accessibility and simplifies the code. Verified with tests and visual inspection via Playwright.

---
*PR created automatically by Jules for task [1053375733818265388](https://jules.google.com/task/1053375733818265388) started by @lingyv-li*