### PR TITLE
🎨 Palette: Semantic Button Refactor & Focus Styles

### DIFF
--- a/src/sidepanel/components/Header.tsx
+++ b/src/sidepanel/components/Header.tsx
@@ -27,7 +27,7 @@ export const Header = ({ isLoading }: HeaderProps) => {
                         type='button'
                         onClick={undoLast}
                         disabled={isUndoing}
-                        className='flex items-center justify-center p-2 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all border border-border-subtle'
+                        className='flex items-center justify-center p-2 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all border border-border-subtle focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none'
                         title='Undo last action'
                         aria-label='Undo last action'
                     >
@@ -35,9 +35,11 @@ export const Header = ({ isLoading }: HeaderProps) => {
                     </button>
                 )}
                 <button
+                    type='button'
                     onClick={() => chrome.runtime.openOptionsPage()}
-                    className='flex items-center gap-2 p-2 px-3 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all duration-200 cursor-pointer'
+                    className='flex items-center gap-2 p-2 px-3 rounded-lg text-muted hover:text-main hover:bg-surface-highlight transition-all duration-200 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none'
                     title='Options'
+                    aria-label='Options'
                 >
                     <Settings className='w-4 h-4' />
                 </button>

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,13 +33,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
         <div
             className={`
@@ -49,12 +42,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+            <button
+                type='button'
+                disabled={disabled || isLoading}
+                className='w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none'
                 onClick={onClick}
-                onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
                 <div
@@ -83,7 +75,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     </span>
                     {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
                 </div>
-            </div>
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+      type="button"
     >
       <div
         class="
@@ -97,7 +96,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -143,11 +142,11 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -231,7 +230,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -277,11 +276,11 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -334,7 +333,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -12,11 +12,10 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
+      <button
         aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+        type="button"
       >
         <div
           class="
@@ -101,7 +100,7 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >
@@ -186,11 +185,10 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
     >
-      <div
+      <button
         aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
+        type="button"
       >
         <div
           class="
@@ -286,7 +284,7 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             />
           </svg>
         </div>
-      </div>
+      </button>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >


### PR DESCRIPTION
💡 What: Refactored `SuggestionItem` to use semantic `<button>` instead of `div role="button"`. Added `aria-label` to the Options button in `Header`. Added visible focus styles (`focus-visible:ring-2`) to interactive elements.
🎯 Why: Improves keyboard navigation, screen reader support, and overall accessibility.
♿ Accessibility:
- Replaced `div role="button"` with native `<button>`, enabling native keyboard interactions (Enter/Space) and focus management.
- Added explicit `aria-label` to icon-only buttons.
- Added clear focus rings for keyboard users.
- Removed manual `tabIndex` and `onKeyDown` handlers.

---
*PR created automatically by Jules for task [8454760490319033742](https://jules.google.com/task/8454760490319033742) started by @lingyv-li*