### PR TITLE
🎨 Palette: Refactor SuggestionItem to native button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Refactoring interactive divs to native buttons
+**Learning:** Using `div role="button"` requires manual handling of keyboard events (Enter/Space) and focus management. Native `<button>` elements handle this automatically and are more robust.
+**Action:** Always prefer `<button>` for interactive elements. If styling is an issue, reset styles but keep the semantic element.

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,13 +33,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
         <div
             className={`
@@ -49,12 +42,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+            <button
+                type='button'
+                disabled={disabled || isLoading}
+                className='w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset'
                 onClick={onClick}
-                onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
                 <div
@@ -83,7 +75,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     </span>
                     {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
                 </div>
-            </div>
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -33,16 +33,18 @@ describe('SuggestionItem', () => {
     it('renders loading state', () => {
         const { asFragment } = render(<SuggestionItem {...defaultProps} isLoading={true} />);
         expect(asFragment()).toMatchSnapshot();
+        expect(screen.getByRole('button')).toBeDisabled();
     });
 
     it('renders disabled state', () => {
         const { asFragment } = render(<SuggestionItem {...defaultProps} disabled={true} />);
         expect(asFragment()).toMatchSnapshot();
+        expect(screen.getByRole('button')).toBeDisabled();
     });
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
     });
 

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      type="button"
     >
       <div
         class="
@@ -97,7 +96,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -143,11 +142,11 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -231,7 +230,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -277,11 +276,11 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -334,7 +333,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >


### PR DESCRIPTION
Refactored `SuggestionItem` to use a native `<button>` element, improving accessibility and reducing custom event handling logic. Updated tests to match the new semantic structure. Verified visually with a temporary harness.

---
*PR created automatically by Jules for task [17126633896279201711](https://jules.google.com/task/17126633896279201711) started by @lingyv-li*