### PR TITLE
🎨 Palette: Refactor Suggestion Items to Native Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Complex Interactive Cards as Buttons
+**Learning:** Interactive cards with nested visual elements (like icons, text, arrows) can often be implemented as single native `<button>` elements instead of `div`s with ARIA roles. This gives native keyboard support (Enter/Space) and focus management for free, reducing code complexity and bugs.
+**Action:** When seeing `div role="button"` wrappers, check if they can be refactored to `<button type="button" className="w-full text-left ...">` to improve accessibility and simplify code.

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -33,13 +33,6 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         return Array.from(groups.values());
     }, [tabs]);
 
-    const handleKeyDown = (e: React.KeyboardEvent) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            if (!disabled && !isLoading) onClick();
-        }
-    };
-
     return (
         <div
             className={`
@@ -49,12 +42,11 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
         `}
         >
             {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
+            <button
+                type='button'
+                disabled={disabled || isLoading}
+                className='w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset'
                 onClick={onClick}
-                onKeyDown={handleKeyDown}
                 aria-label={`${title}: ${description}. Apply suggestion.`}
             >
                 <div
@@ -83,7 +75,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
                     </span>
                     {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
                 </div>
-            </div>
+            </button>
 
             {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -42,8 +42,14 @@ describe('SuggestionItem', () => {
 
     it('handles clicks', () => {
         render(<SuggestionItem {...defaultProps} />);
-        fireEvent.click(screen.getByText('Test Suggestion').closest('div')!.parentElement!);
+        fireEvent.click(screen.getByRole('button', { name: /Test Suggestion/i }));
         expect(defaultProps.onClick).toHaveBeenCalled();
+    });
+
+    it('has accessible name', () => {
+        render(<SuggestionItem {...defaultProps} />);
+        const button = screen.getByRole('button', { name: 'Test Suggestion: Test Description. Apply suggestion.' });
+        expect(button).toBeInTheDocument();
     });
 
     it('groups identical tabs visually', () => {

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -9,11 +9,10 @@ exports[`SuggestionItem > renders correctly 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      type="button"
     >
       <div
         class="
@@ -97,7 +96,7 @@ exports[`SuggestionItem > renders correctly 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -143,11 +142,11 @@ exports[`SuggestionItem > renders disabled state 1`] = `
             opacity-50 pointer-events-none
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -231,7 +230,7 @@ exports[`SuggestionItem > renders disabled state 1`] = `
           />
         </svg>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
@@ -277,11 +276,11 @@ exports[`SuggestionItem > renders loading state 1`] = `
             hover:border-action hover:bg-surface-highlight border-border-subtle
         "
   >
-    <div
+    <button
       aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="w-full text-left flex items-center gap-2 p-2 cursor-pointer focus-visible:ring-2 focus-visible:ring-brand-local focus-visible:outline-none focus-visible:ring-inset"
+      disabled=""
+      type="button"
     >
       <div
         class="
@@ -334,7 +333,7 @@ exports[`SuggestionItem > renders loading state 1`] = `
           Apply
         </span>
       </div>
-    </div>
+    </button>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >


### PR DESCRIPTION
💡 **What:** Refactored `SuggestionItem` components from `div role="button"` to native `<button>` elements.
🎯 **Why:** Improves keyboard accessibility (tab focus, Enter/Space activation) and semantic structure without relying on manual event handlers.
📸 **Before/After:** No visual change (verified via screenshot), but significant accessibility improvement.
♿ **Accessibility:** Native focus management, automatic key handling, proper role and state exposure.

---
*PR created automatically by Jules for task [730470972814630352](https://jules.google.com/task/730470972814630352) started by @lingyv-li*