### PR TITLE
fix: exclude pinned tabs from grouping

### DIFF
--- a/src/utils/__tests__/tabFilter.test.ts
+++ b/src/utils/__tests__/tabFilter.test.ts
@@ -19,6 +19,7 @@ describe('tabFilter', () => {
             url: 'https://example.com',
             title: 'Example',
             status: 'complete',
+            pinned: false,
             groupId: -1 // TAB_ID_NONE
         };
 
@@ -52,6 +53,10 @@ describe('tabFilter', () => {
         });
         it('should return false for grouped tabs', () => {
             const tab = { ...baseTab, groupId: 1 };
+            expect(isGroupableTab(tab as chrome.tabs.Tab)).toBe(false);
+        });
+        it('should return false for pinned tabs', () => {
+            const tab = { ...baseTab, pinned: true };
             expect(isGroupableTab(tab as chrome.tabs.Tab)).toBe(false);
         });
     });

--- a/src/utils/tabFilter.ts
+++ b/src/utils/tabFilter.ts
@@ -24,6 +24,11 @@ export function isGroupableTab(tab: chrome.tabs.Tab): boolean {
         return false;
     }
 
+    // Skip pinned tabs - grouping them breaks the pin
+    if (tab.pinned) {
+        return false;
+    }
+
     // Skip tabs that are already grouped - we only want to suggest groups for ungrouped tabs
     if (tab.groupId !== chrome.tabs.TAB_ID_NONE) {
         return false;


### PR DESCRIPTION
Grouping pinned tabs breaks their pinned state in Chrome. Added a check in `isGroupableTab` to skip tabs with `pinned: true`, along with a corresponding test.

Fixes #92

Generated with [Claude Code](https://claude.ai/code)