### PR TITLE
feat: feedback memory — learn from dismissed suggestions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,8 @@
       "Bash(npm run test:*)",
       "Bash(jj commit:*)",
       "Bash(npm run lint:*)",
-      "Bash(jj log:*)"
+      "Bash(jj log:*)",
+      "Bash(jj diff:*)"
     ]
   }
 }

--- a/docs/design-feedback-memory.md
+++ b/docs/design-feedback-memory.md
@@ -1,0 +1,128 @@
+# Design: Feedback Memory System
+
+**Status**: Proposal
+**Date**: 2026-04-06
+
+## Goal
+
+The system learns from user dismissals to improve future grouping suggestions. When a user dismisses a suggestion, the AI distills the rejection into a short preference rule that generalizes to future tabs. Over time, the system builds a compact set of learned preferences that shape the AI prompt.
+
+## Design Principles
+
+1. **Dismiss = signal.** The act of dismissing is the only required input. No feedback forms or reason codes.
+2. **Store what was rejected, not why.** The rejected group name + tab titles/hostnames is the data. The AI infers the pattern.
+3. **Distill, don't accumulate.** The AI compresses rejected examples into short generalizable rules. Raw rejection snapshots are transient; learned rules are durable.
+4. **Budget is fixed.** Learned preferences have a hard character cap. New learnings compete for space. The memory is self-compacting — the AI re-summarizes when it overflows.
+5. **Free-form only.** User-written custom rules and AI-learned rules coexist as plain text. No profiles, no structured settings.
+
+## Data Flow
+
+```
+User dismisses suggestion
+  → store rejection snapshot in session storage
+  → on next processing cycle, AI distills pending rejections into preference rules
+  → append rules to learned preferences in local storage
+  → compress if over budget
+  → inject into AI prompt alongside user's custom rules
+```
+
+## Rejection Snapshot
+
+Captured on dismiss. Stored in `chrome.storage.session` (transient — cleared on browser restart). Key: `pendingRejections`. Capped at 20 entries.
+
+```ts
+interface RejectionSnapshot {
+  groupName: string;
+  tabs: { title: string; hostname: string }[];
+  timestamp: string; // ISO
+}
+```
+
+Only tab titles and hostnames are stored — no full URLs. This keeps the data minimal and avoids leaking sensitive URL parameters.
+
+## Distillation
+
+At the start of each `QueueProcessor` cycle, before building the AI prompt:
+
+1. Read and clear `pendingRejections` from session storage.
+2. If non-empty, make one AI call with the rejections as context:
+
+```
+The user rejected these proposed tab groupings:
+
+1. Group "Research": ["React useEffect cleanup - Stack Overflow", "Fix memory leak - GitHub PR #45", "useEffect reference - React docs"]
+2. Group "Shopping": ["AirPods Max - Amazon", "Best noise cancelling headphones 2026 - Reddit"]
+
+Each rejection means the user did NOT want those tabs grouped that way.
+Write 1-2 short rules (one sentence each) that capture what the user probably prefers.
+Rules should generalize beyond these specific tabs.
+Only write rules if there is a clear pattern. If the rejection seems arbitrary, write nothing.
+```
+
+3. Append returned rules to `learnedPreferences` in `chrome.storage.local`.
+
+Example output:
+- "Separate active code review from reference documentation — don't group PRs with docs/SO."
+- "Don't group product pages with discussion forums about those products."
+
+## Memory Budget
+
+**Hard cap: 500 characters** for `learnedPreferences`. This fits roughly 5-8 short rules and keeps prompt overhead minimal.
+
+When appending new rules would exceed the cap, the AI re-summarizes all rules (existing + new) to fit within the budget:
+
+```
+Compress these tab grouping preference rules into at most 500 characters.
+Merge overlapping rules. Drop the least important if needed.
+Keep the most specific, actionable rules.
+
+[all rules]
+```
+
+This makes the memory **self-compacting**: early rules fold into broader patterns as more feedback accumulates. The system never grows unbounded, and the most reinforced patterns survive compression.
+
+## Storage
+
+```ts
+// chrome.storage.session (transient, cleared on restart)
+{
+  pendingRejections: RejectionSnapshot[]  // max 20
+}
+
+// chrome.storage.local (durable, device-local)
+{
+  learnedPreferences: string  // max 500 chars, plain text rules
+}
+```
+
+All feedback data uses local/session storage only — no sync storage, avoiding the 100KB sync quota constraint.
+
+## Prompt Structure
+
+The AI prompt for grouping includes learned preferences after the user's custom rules:
+
+```
+[user's custom grouping rules OR defaults]
+
+## Learned from your usage
+[learnedPreferences, verbatim]
+```
+
+The section is omitted when `learnedPreferences` is empty.
+
+## UI
+
+- Each suggestion card has a dismiss (X) button. Clicking it removes the suggestion and records a rejection snapshot. No follow-up form.
+- The `DismissSuggestion` message flows from the sidepanel through the port to the background service worker, which removes the suggestion from the cache and stores the snapshot.
+- Learned preferences are shown as read-only text in the settings page, beneath the custom rules textarea, so users can see what the system has learned.
+
+## Cost
+
+- **Per dismiss**: 0 API calls. Session storage write only.
+- **Per processing cycle with pending rejections**: 1 extra AI call for distillation. This piggybacks on cycles already making AI calls.
+- **Per budget overflow**: 1 extra AI call for compression. Infrequent — only when accumulated rules exceed 500 chars.
+- **Typical case**: 0 extra calls (no pending rejections most cycles).
+
+## Local-Only Mode
+
+Distillation requires an AI call. For users on Gemini Nano only, the model may not reliably produce good rule summaries. In this case, the system falls back to storing the last N raw rejection snapshots (group name + tab list) and injecting them directly as negative examples in the prompt, without distillation.

--- a/docs/superpowers/plans/2026-04-06-feedback-memory.md
+++ b/docs/superpowers/plans/2026-04-06-feedback-memory.md
@@ -1,0 +1,1112 @@
+# Feedback Memory System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the pending profile/feedback-form implementation with a dismiss-driven memory system that distills rejected suggestions into learned AI preferences.
+
+**Architecture:** Dismissing a suggestion stores a `RejectionSnapshot` in session storage. At the start of each AI processing cycle, the background service worker pops pending rejections and calls the AI (Gemini only) to distill them into short preference rules, stored in local storage under `learnedPreferences` with a 500-char cap. These learned preferences are appended to the effective prompt rules alongside the user's free-form custom rules. For local-only users, pending rejections are injected as raw negative examples instead.
+
+**Tech Stack:** TypeScript, Chrome Extension APIs (storage.session + storage.local), Google GenAI SDK (`@google/genai`), React, Vitest
+
+---
+
+## File Map
+
+**Delete:**
+- `src/types/feedback.ts`
+- `src/types/profiles.ts`
+- `src/utils/feedbackStorage.ts`
+- `src/utils/personalization.ts`
+- `src/utils/__tests__/feedbackStorage.test.ts`
+- `src/utils/__tests__/personalization.test.ts`
+
+**Create:**
+- `src/types/rejection.ts` — `RejectionSnapshot` interface
+- `src/utils/rejectionMemory.ts` — session/local storage helpers + `getEffectiveRules`
+- `src/utils/distillation.ts` — AI distillation + compression logic
+- `src/utils/__tests__/rejectionMemory.test.ts`
+- `src/utils/__tests__/distillation.test.ts`
+
+**Modify:**
+- `src/utils/storage.ts` — remove `personalizationProfiles`, `activePersonalization`, `ActivePersonalization` type
+- `src/services/ai/types.ts` — add `canSummarize: boolean` and `summarize()` to `AIProvider`
+- `src/services/ai/GeminiProvider.ts` — implement `summarize()`
+- `src/services/ai/LocalProvider.ts` — stub `canSummarize = false`
+- `src/background/index.ts` — capture `RejectionSnapshot` before removing suggestions
+- `src/background/queueProcessor.ts` — call distillation; hoist `getEffectiveRules` outside batch loop; pass `effectiveRules` into `processWindowBatch`
+- `src/background/__tests__/queueProcessor.test.ts` — update mocks
+- `src/background/__tests__/integration/setup.ts` — remove profile fields from default settings
+- `src/sidepanel/components/SuggestionItem.tsx` — remove `FeedbackForm`, `feedbackContext`, `tabIds` props; keep `onDismiss` + X button
+- `src/sidepanel/components/SuggestionList.tsx` — remove `feedbackContext` wiring
+- `src/sidepanel/components/__tests__/SuggestionItem.test.tsx` — remove feedback tests
+- `src/sidepanel/components/__tests__/SuggestionList.test.tsx` — remove feedback mock
+- `src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap` — delete (regenerate)
+- `src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap` — delete (regenerate)
+- `src/options/index.tsx` — remove profile editor; add read-only learned preferences section
+
+---
+
+## Task 1: Strip profile and feedback cruft
+
+**Files:**
+- Delete: `src/types/feedback.ts`, `src/types/profiles.ts`, `src/utils/feedbackStorage.ts`, `src/utils/personalization.ts`
+- Delete: `src/utils/__tests__/feedbackStorage.test.ts`, `src/utils/__tests__/personalization.test.ts`
+- Modify: `src/utils/storage.ts`
+- Modify: `src/sidepanel/components/SuggestionItem.tsx`
+- Modify: `src/sidepanel/components/SuggestionList.tsx`
+- Modify: `src/options/index.tsx`
+- Delete: `src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap`
+- Delete: `src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap`
+
+- [ ] **Step 1: Delete unused files**
+
+```bash
+rm src/types/feedback.ts src/types/profiles.ts
+rm src/utils/feedbackStorage.ts src/utils/personalization.ts
+rm src/utils/__tests__/feedbackStorage.test.ts src/utils/__tests__/personalization.test.ts
+rm src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+rm src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+```
+
+- [ ] **Step 2: Clean `src/utils/storage.ts`**
+
+Remove the `PersonalizationProfile` import, `ActivePersonalization` type, and the two fields from `SyncedSettings` and `DEFAULT_SYNCED_SETTINGS`.
+
+Replace the top of the file so it reads:
+
+```ts
+import { FeatureId } from '../types/features';
+
+export enum AIProviderType {
+    Local = 'local',
+    Gemini = 'gemini',
+    None = 'none'
+}
+
+export interface FeatureSettings {
+    enabled: boolean;
+    autopilot: boolean;
+}
+
+export interface SyncedSettings {
+    customGroupingRules: string;
+    geminiApiKey: string;
+    hasCompletedOnboarding: boolean;
+    features: Record<FeatureId, FeatureSettings>;
+}
+```
+
+And `DEFAULT_SYNCED_SETTINGS`:
+```ts
+export const DEFAULT_SYNCED_SETTINGS: SyncedSettings = {
+    customGroupingRules: '',
+    geminiApiKey: '',
+    hasCompletedOnboarding: false,
+    features: {
+        [FeatureId.TabGrouper]: { enabled: false, autopilot: false },
+        [FeatureId.DuplicateCleaner]: { enabled: true, autopilot: false }
+    }
+};
+```
+
+- [ ] **Step 3: Simplify `src/sidepanel/components/SuggestionItem.tsx`**
+
+Replace the entire file with the version below — removes `FeedbackForm`, `feedbackContext`, `tabIds`, but keeps `onDismiss` and the X button:
+
+```tsx
+import React from 'react';
+import { LucideIcon, ArrowRight, Loader2, X } from 'lucide-react';
+import { SuggestionType, SuggestionTab } from '../../types/suggestions';
+
+interface SuggestionItemProps {
+    title: string;
+    description: string;
+    icon: LucideIcon;
+    type: SuggestionType;
+    onClick: () => void;
+    onDismiss?: () => void;
+    isLoading?: boolean;
+    disabled?: boolean;
+    tabs?: SuggestionTab[];
+}
+
+export const SuggestionItem: React.FC<SuggestionItemProps> = ({
+    title,
+    description,
+    icon: Icon,
+    type,
+    onClick,
+    onDismiss,
+    isLoading,
+    disabled,
+    tabs
+}) => {
+    const canReject = !!onDismiss && type === SuggestionType.Group;
+
+    const groupedTabs = React.useMemo(() => {
+        if (!tabs) return [];
+        const groups = new Map<string, { count: number; tab: (typeof tabs)[0] }>();
+        tabs.forEach(tab => {
+            const key = `${tab.title || ''}|${tab.favIconUrl || ''}`;
+            const existing = groups.get(key);
+            if (existing) existing.count++;
+            else groups.set(key, { count: 1, tab });
+        });
+        return Array.from(groups.values());
+    }, [tabs]);
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (!disabled && !isLoading) onClick();
+        }
+    };
+
+    return (
+        <div
+            role='button'
+            tabIndex={disabled || isLoading ? -1 : 0}
+            className={`
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            ${disabled ? 'opacity-50 pointer-events-none' : '[&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight'}
+        `}
+            onClick={onClick}
+            onKeyDown={handleKeyDown}
+            aria-label={`${title}: ${description}. Apply suggestion.`}
+        >
+            <div className='flex items-center gap-2 p-2'>
+                <div className='flex flex-1 min-w-0 items-center gap-2'>
+                    <div className={`p-1.5 rounded-md shrink-0 ${type === SuggestionType.Group ? 'bg-indigo-500/10 text-indigo-500' : 'bg-rose-500/10 text-rose-500'}`}>
+                        {isLoading ? <Loader2 className='w-4 h-4 animate-spin' /> : <Icon className='w-4 h-4' />}
+                    </div>
+                    <div className='flex-1 min-w-0'>
+                        <h3 className='font-medium text-main truncate text-sm leading-tight'>{title}</h3>
+                        <p className='text-[10px] text-muted truncate leading-tight'>{description}</p>
+                    </div>
+                    <div
+                        className={`
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        ${isLoading ? 'opacity-0' : ''}
+                    `}
+                    >
+                        <span className='text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap'>
+                            Apply
+                        </span>
+                        {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
+                    </div>
+                </div>
+                {canReject && (
+                    <button
+                        type='button'
+                        className='reject-btn p-1.5 rounded-lg text-muted cursor-pointer hover:text-action hover:bg-surface-highlight shrink-0 transition-colors duration-200'
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onDismiss();
+                        }}
+                        aria-label='Reject suggestion'
+                    >
+                        <X className='w-4 h-4' />
+                    </button>
+                )}
+            </div>
+            {groupedTabs.length > 0 && (
+                <div className='px-2 pb-2 pl-9 space-y-0.5'>
+                    {groupedTabs.map(({ tab, count }, idx) => (
+                        <div key={idx} className='flex items-center gap-1.5 min-w-0'>
+                            {tab.favIconUrl ? (
+                                <img src={tab.favIconUrl} className='w-3 h-3 shrink-0 rounded-sm' alt='' />
+                            ) : (
+                                <div className='w-3 h-3 shrink-0 rounded-sm bg-border-subtle' />
+                            )}
+                            <span className='text-[10px] text-muted truncate leading-tight flex-1'>{tab.title || tab.url}</span>
+                            {count > 1 && <span className='text-[10px] text-muted shrink-0 font-medium'>x{count}</span>}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+```
+
+- [ ] **Step 4: Simplify `src/sidepanel/components/SuggestionList.tsx`**
+
+Remove `feedbackContext` and `tabIds` wiring. The `onDismiss` prop is still passed (it calls `dismissSuggestion`). Replace the `SuggestionItem` call block and remove the unused `FeedbackContext` import:
+
+```tsx
+import React, { useMemo } from 'react';
+import { Group, Trash2, Sparkles, Loader2, LucideIcon } from 'lucide-react';
+import { useTabGrouper } from '../../hooks/useTabGrouper';
+import { useDuplicateCleaner } from '../../hooks/useDuplicateCleaner';
+import { SuggestionItem } from './SuggestionItem';
+import { SuggestionType } from '../../types/suggestions';
+import { groupSuggestionKey } from '../../utils/groupSuggestionKey';
+```
+
+(Remove `type { FeedbackContext }` import from SuggestionItem and the `getDomainsFromTabs` helper.)
+
+In the `UnifiedSuggestion` interface, remove `groupName?`, `tabIds?`, `feedbackContext?`.
+
+In the render:
+```tsx
+<SuggestionItem
+    key={item.id}
+    title={item.title}
+    description={item.description}
+    icon={item.icon}
+    type={item.type}
+    onClick={() => handleAction(item.id, item.onClick)}
+    onDismiss={item.tabIds?.length ? () => dismissSuggestion(item.tabIds!) : undefined}
+    isLoading={processingId === item.id}
+    disabled={(processingId !== null && processingId !== item.id) || isAcceptingAll}
+    tabs={item.tabs.map(t => ({ title: t.title, url: t.url, favIconUrl: t.favIconUrl }))}
+/>
+```
+
+Keep `tabIds` on `UnifiedSuggestion` only for the `onDismiss` closure — remove `feedbackContext` and `groupName`.
+
+- [ ] **Step 5: Strip profile editor from `src/options/index.tsx`**
+
+Remove these imports: `User, Plus, Pencil, Trash2` from lucide-react and `type { PersonalizationProfile, GranularityPreference }` from profiles.
+
+Remove these state declarations:
+```ts
+const [editingProfile, setEditingProfile] = useState<PersonalizationProfile | null>(null);
+const profiles = settings.personalizationProfiles ?? [];
+const activePersonalization = settings.activePersonalization ?? 'freeform';
+```
+
+Remove `handleAddProfile`, `handleEditProfile`, `handleSaveProfile`, `handleDeleteProfile` functions.
+
+Replace the entire "Personalization" section (the `<div className='space-y-4'>` that contains the tab switcher and profile editor) with the original "Grouping Rules" section:
+
+```tsx
+<div className='space-y-4'>
+    <h2 className='text-xs font-bold uppercase tracking-wider text-muted pl-1'>Grouping Rules</h2>
+
+    <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle group hover:border-teal-500/30 transition-colors focus-within:border-teal-500/50'>
+        <label className='block font-medium text-main mb-2'>Custom AI Instructions</label>
+        <p className='text-sm text-muted mb-3'>
+            Add specific rules for the AI to follow when grouping tabs (e.g., &quot;Group all Jira tickets together&quot;).
+        </p>
+        <textarea
+            value={settings.customGroupingRules}
+            onChange={e => setSettings(s => ({ ...s, customGroupingRules: e.target.value }))}
+            placeholder={DEFAULT_GROUPING_RULES}
+            className='w-full h-32 bg-surface/50 rounded-xl border border-border-subtle p-3 text-sm text-main placeholder:text-muted/50 focus:outline-none focus:ring-2 focus:ring-teal-500/20 transition-all resize-none'
+        />
+    </div>
+</div>
+```
+
+- [ ] **Step 6: Run tests and fix any type errors**
+
+```bash
+npm run test 2>&1 | head -60
+npm run build 2>&1 | tail -30
+```
+
+Expected: type errors about missing `personalizationProfiles`/`activePersonalization` in test setup and queueProcessor mock. Fix them in the next step.
+
+- [ ] **Step 7: Fix `src/background/__tests__/integration/setup.ts`**
+
+Find the `initializeSettings` call (around line 367) and remove the two profile fields:
+
+```ts
+await SettingsStorage.set({
+    customGroupingRules: '',
+    geminiApiKey: '',
+    hasCompletedOnboarding: true,
+    aiModel: ''
+});
+```
+
+- [ ] **Step 8: Fix `src/background/__tests__/queueProcessor.test.ts`**
+
+Remove the `vi.mock('../../utils/personalization', ...)` block entirely (3 lines).
+
+- [ ] **Step 9: Update `src/sidepanel/components/__tests__/SuggestionItem.test.tsx`**
+
+Remove `vi.mock('../../../utils/feedbackStorage', ...)`.
+
+Remove the entire `describe('feedback / Skip independence', ...)` block.
+
+- [ ] **Step 10: Update `src/sidepanel/components/__tests__/SuggestionList.test.tsx`**
+
+Remove `vi.mock('../../../utils/feedbackStorage', ...)`.
+
+Remove all `dismissSuggestion: mockDismissSuggestion` entries from the mock return values (3 places).
+
+Also remove `const mockDismissSuggestion = vi.fn();`.
+
+- [ ] **Step 11: Verify tests pass**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass, snapshots regenerate.
+
+- [ ] **Step 12: Commit**
+
+```bash
+jj commit -m "chore: strip profile and feedback-form system
+
+Remove personalization profiles, feedback reason codes, and the
+feedback form UI. The dismiss button remains; memory will be rebuilt
+from rejection snapshots in the next commits."
+```
+
+---
+
+## Task 2: Add rejection memory types and storage helpers
+
+**Files:**
+- Create: `src/types/rejection.ts`
+- Create: `src/utils/rejectionMemory.ts`
+- Create: `src/utils/__tests__/rejectionMemory.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/utils/__tests__/rejectionMemory.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { storePendingRejection, popPendingRejections, getLearnedPreferences, setLearnedPreferences, clearLearnedPreferences, getEffectiveRules } from '../rejectionMemory';
+import type { RejectionSnapshot } from '../../types/rejection';
+import { DEFAULT_GROUPING_RULES } from '../storage';
+import type { AppSettings } from '../storage';
+
+const mockSessionGet = vi.fn();
+const mockSessionSet = vi.fn();
+const mockSessionRemove = vi.fn();
+const mockLocalGet = vi.fn();
+const mockLocalSet = vi.fn();
+const mockLocalRemove = vi.fn();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionGet.mockResolvedValue({});
+    mockSessionSet.mockResolvedValue(undefined);
+    mockSessionRemove.mockResolvedValue(undefined);
+    mockLocalGet.mockResolvedValue({});
+    mockLocalSet.mockResolvedValue(undefined);
+    mockLocalRemove.mockResolvedValue(undefined);
+    const g = global as unknown as { chrome: unknown };
+    g.chrome = {
+        storage: {
+            session: { get: mockSessionGet, set: mockSessionSet, remove: mockSessionRemove },
+            local: { get: mockLocalGet, set: mockLocalSet, remove: mockLocalRemove }
+        }
+    };
+});
+
+const snap: RejectionSnapshot = {
+    groupName: 'Work',
+    tabs: [{ title: 'PR #1', hostname: 'github.com' }],
+    timestamp: '2026-01-01T00:00:00.000Z'
+};
+
+describe('storePendingRejection', () => {
+    it('appends to empty list', async () => {
+        mockSessionGet.mockResolvedValue({ pendingRejections: [] });
+        await storePendingRejection(snap);
+        expect(mockSessionSet).toHaveBeenCalledWith({ pendingRejections: [snap] });
+    });
+
+    it('prunes to max 20', async () => {
+        const existing = Array.from({ length: 20 }, (_, i) => ({ ...snap, groupName: `G${i}` }));
+        mockSessionGet.mockResolvedValue({ pendingRejections: existing });
+        await storePendingRejection(snap);
+        const saved = mockSessionSet.mock.calls[0][0].pendingRejections as RejectionSnapshot[];
+        expect(saved.length).toBe(20);
+        expect(saved[saved.length - 1]?.groupName).toBe('Work');
+    });
+});
+
+describe('popPendingRejections', () => {
+    it('returns list and removes from storage', async () => {
+        mockSessionGet.mockResolvedValue({ pendingRejections: [snap] });
+        const result = await popPendingRejections();
+        expect(result).toEqual([snap]);
+        expect(mockSessionRemove).toHaveBeenCalledWith('pendingRejections');
+    });
+
+    it('returns empty array when nothing stored', async () => {
+        const result = await popPendingRejections();
+        expect(result).toEqual([]);
+        expect(mockSessionRemove).not.toHaveBeenCalled();
+    });
+});
+
+describe('getLearnedPreferences / setLearnedPreferences / clearLearnedPreferences', () => {
+    it('returns empty string by default', async () => {
+        expect(await getLearnedPreferences()).toBe('');
+    });
+
+    it('round-trips through set/get', async () => {
+        mockLocalGet.mockResolvedValue({ learnedPreferences: '- Keep code separate from docs.' });
+        expect(await getLearnedPreferences()).toBe('- Keep code separate from docs.');
+    });
+
+    it('clearLearnedPreferences removes the key', async () => {
+        await clearLearnedPreferences();
+        expect(mockLocalRemove).toHaveBeenCalledWith('learnedPreferences');
+    });
+});
+
+describe('getEffectiveRules', () => {
+    it('returns default rules when customGroupingRules is empty and no learned prefs', async () => {
+        const settings = { customGroupingRules: '' } as AppSettings;
+        expect(await getEffectiveRules(settings)).toBe(DEFAULT_GROUPING_RULES);
+    });
+
+    it('returns custom rules when set', async () => {
+        const settings = { customGroupingRules: 'My rules.' } as AppSettings;
+        expect(await getEffectiveRules(settings)).toBe('My rules.');
+    });
+
+    it('appends learned preferences when present', async () => {
+        mockLocalGet.mockResolvedValue({ learnedPreferences: '- No mixing docs with PRs.' });
+        const settings = { customGroupingRules: 'My rules.' } as AppSettings;
+        const result = await getEffectiveRules(settings);
+        expect(result).toContain('My rules.');
+        expect(result).toContain('## Learned from your usage');
+        expect(result).toContain('- No mixing docs with PRs.');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+npm run test src/utils/__tests__/rejectionMemory.test.ts 2>&1 | tail -10
+```
+
+Expected: `Cannot find module '../rejectionMemory'`
+
+- [ ] **Step 3: Create `src/types/rejection.ts`**
+
+```ts
+export interface RejectionSnapshot {
+    /** Group name the AI proposed */
+    groupName: string;
+    /** Tab titles + hostnames only — no full URLs */
+    tabs: { title: string; hostname: string }[];
+    /** ISO timestamp */
+    timestamp: string;
+}
+```
+
+- [ ] **Step 4: Create `src/utils/rejectionMemory.ts`**
+
+```ts
+import type { RejectionSnapshot } from '../types/rejection';
+import type { AppSettings } from './storage';
+import { DEFAULT_GROUPING_RULES } from './storage';
+
+const PENDING_REJECTIONS_KEY = 'pendingRejections';
+const LEARNED_PREFERENCES_KEY = 'learnedPreferences';
+const MAX_PENDING = 20;
+export const LEARNED_PREFERENCES_MAX_LENGTH = 500;
+
+export async function storePendingRejection(snapshot: RejectionSnapshot): Promise<void> {
+    const result = await chrome.storage.session.get(PENDING_REJECTIONS_KEY);
+    const list: RejectionSnapshot[] = Array.isArray(result[PENDING_REJECTIONS_KEY]) ? result[PENDING_REJECTIONS_KEY] : [];
+    list.push(snapshot);
+    await chrome.storage.session.set({ [PENDING_REJECTIONS_KEY]: list.slice(-MAX_PENDING) });
+}
+
+export async function popPendingRejections(): Promise<RejectionSnapshot[]> {
+    const result = await chrome.storage.session.get(PENDING_REJECTIONS_KEY);
+    const list: RejectionSnapshot[] = Array.isArray(result[PENDING_REJECTIONS_KEY]) ? result[PENDING_REJECTIONS_KEY] : [];
+    if (list.length > 0) {
+        await chrome.storage.session.remove(PENDING_REJECTIONS_KEY);
+    }
+    return list;
+}
+
+export async function getLearnedPreferences(): Promise<string> {
+    const result = await chrome.storage.local.get(LEARNED_PREFERENCES_KEY);
+    const raw = result[LEARNED_PREFERENCES_KEY];
+    return typeof raw === 'string' ? raw : '';
+}
+
+export async function setLearnedPreferences(prefs: string): Promise<void> {
+    await chrome.storage.local.set({ [LEARNED_PREFERENCES_KEY]: prefs });
+}
+
+export async function clearLearnedPreferences(): Promise<void> {
+    await chrome.storage.local.remove(LEARNED_PREFERENCES_KEY);
+}
+
+export async function getEffectiveRules(settings: AppSettings): Promise<string> {
+    const baseRules = settings.customGroupingRules?.trim() || DEFAULT_GROUPING_RULES;
+    const learned = await getLearnedPreferences();
+    if (learned.trim()) {
+        return `${baseRules}\n\n## Learned from your usage\n${learned.trim()}`;
+    }
+    return baseRules;
+}
+```
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```bash
+npm run test src/utils/__tests__/rejectionMemory.test.ts 2>&1 | tail -10
+```
+
+Expected: all 8 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat: add rejection memory storage
+
+RejectionSnapshot type + helpers to store pending rejections in session
+storage and learned preferences in local storage, with getEffectiveRules
+replacing the old personalization.ts."
+```
+
+---
+
+## Task 3: Add `summarize` capability to AI providers
+
+**Files:**
+- Modify: `src/services/ai/types.ts`
+- Modify: `src/services/ai/GeminiProvider.ts`
+- Modify: `src/services/ai/LocalProvider.ts`
+
+- [ ] **Step 1: Extend `AIProvider` interface in `src/services/ai/types.ts`**
+
+Add two members after `id`:
+
+```ts
+export interface AIProvider {
+    id: string;
+
+    /**
+     * Whether this provider can summarize free-form text.
+     * LocalProvider returns false — Gemini Nano is not reliable for summarization.
+     */
+    canSummarize: boolean;
+
+    /**
+     * Free-form text summarization. Only call when canSummarize is true.
+     * Used for distilling rejection snapshots into preference rules.
+     */
+    summarize(prompt: string, signal: AbortSignal): Promise<string>;
+
+    generateSuggestions(request: GroupingRequest): Promise<SuggestionResult>;
+}
+```
+
+- [ ] **Step 2: Implement `summarize` in `src/services/ai/GeminiProvider.ts`**
+
+Add after `id = 'gemini';`:
+
+```ts
+canSummarize = true;
+
+async summarize(prompt: string, signal: AbortSignal): Promise<string> {
+    return this.promptAI(prompt, 'You are a concise assistant helping refine AI tab-grouping rules.', signal);
+}
+```
+
+- [ ] **Step 3: Implement stub in `src/services/ai/LocalProvider.ts`**
+
+Add after `id = 'local';`:
+
+```ts
+canSummarize = false;
+
+async summarize(_prompt: string, _signal: AbortSignal): Promise<string> {
+    return '';
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+npm run build 2>&1 | grep -E "error TS" | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat: add summarize capability to AI providers
+
+GeminiProvider implements free-form summarization via promptAI.
+LocalProvider stubs it out (canSummarize = false) since Nano is
+not reliable for distillation."
+```
+
+---
+
+## Task 4: Add distillation service
+
+**Files:**
+- Create: `src/utils/distillation.ts`
+- Create: `src/utils/__tests__/distillation.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/utils/__tests__/distillation.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { distillRejections, processDistillation } from '../distillation';
+import type { RejectionSnapshot } from '../../types/rejection';
+import type { AIProvider } from '../../services/ai/types';
+
+vi.mock('../rejectionMemory', () => ({
+    popPendingRejections: vi.fn(),
+    getLearnedPreferences: vi.fn().mockResolvedValue(''),
+    setLearnedPreferences: vi.fn(),
+    LEARNED_PREFERENCES_MAX_LENGTH: 500
+}));
+
+import { popPendingRejections, getLearnedPreferences, setLearnedPreferences } from '../rejectionMemory';
+
+const makeProvider = (canSummarize: boolean, response = ''): AIProvider => ({
+    id: 'test',
+    canSummarize,
+    summarize: vi.fn().mockResolvedValue(response),
+    generateSuggestions: vi.fn() as AIProvider['generateSuggestions']
+});
+
+const snap: RejectionSnapshot = {
+    groupName: 'Work',
+    tabs: [
+        { title: 'PR #45', hostname: 'github.com' },
+        { title: 'useEffect docs', hostname: 'react.dev' }
+    ],
+    timestamp: '2026-01-01T00:00:00.000Z'
+};
+
+const signal = new AbortController().signal;
+
+describe('distillRejections', () => {
+    it('returns empty string for local provider', async () => {
+        const provider = makeProvider(false);
+        expect(await distillRejections([snap], provider, signal)).toBe('');
+    });
+
+    it('returns empty string for empty rejections', async () => {
+        const provider = makeProvider(true, '- Some rule.');
+        expect(await distillRejections([], provider, signal)).toBe('');
+    });
+
+    it('calls summarize with formatted prompt and returns trimmed result', async () => {
+        const provider = makeProvider(true, '  - Keep PRs separate from docs.  ');
+        const result = await distillRejections([snap], provider, signal);
+        expect(result).toBe('- Keep PRs separate from docs.');
+        expect(provider.summarize).toHaveBeenCalledWith(expect.stringContaining('Group "Work"'), signal);
+        expect(provider.summarize).toHaveBeenCalledWith(expect.stringContaining('github.com'), signal);
+    });
+});
+
+describe('processDistillation', () => {
+    beforeEach(() => {
+        vi.mocked(popPendingRejections).mockResolvedValue([snap]);
+        vi.mocked(getLearnedPreferences).mockResolvedValue('');
+        vi.mocked(setLearnedPreferences).mockResolvedValue(undefined);
+    });
+
+    it('does nothing when no pending rejections', async () => {
+        vi.mocked(popPendingRejections).mockResolvedValue([]);
+        const provider = makeProvider(true, '- A rule.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when provider cannot summarize', async () => {
+        const provider = makeProvider(false);
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).not.toHaveBeenCalled();
+    });
+
+    it('stores new rules when under budget', async () => {
+        const provider = makeProvider(true, '- Keep PRs separate from docs.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Keep PRs separate from docs.');
+    });
+
+    it('appends to existing preferences when combined is under budget', async () => {
+        vi.mocked(getLearnedPreferences).mockResolvedValue('- Existing rule.');
+        const provider = makeProvider(true, '- New rule.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Existing rule.\n- New rule.');
+    });
+
+    it('compresses when combined exceeds budget', async () => {
+        const longExisting = '- ' + 'x'.repeat(490);
+        vi.mocked(getLearnedPreferences).mockResolvedValue(longExisting);
+        const provider = makeProvider(true, '- New rule.');
+        (provider.summarize as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce('- New rule.')      // distill call
+            .mockResolvedValueOnce('- Compressed.');   // compress call
+        await processDistillation(provider, signal);
+        expect(provider.summarize).toHaveBeenCalledTimes(2);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Compressed.');
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+npm run test src/utils/__tests__/distillation.test.ts 2>&1 | tail -10
+```
+
+Expected: `Cannot find module '../distillation'`
+
+- [ ] **Step 3: Create `src/utils/distillation.ts`**
+
+```ts
+import type { RejectionSnapshot } from '../types/rejection';
+import type { AIProvider } from '../services/ai/types';
+import { popPendingRejections, getLearnedPreferences, setLearnedPreferences, LEARNED_PREFERENCES_MAX_LENGTH } from './rejectionMemory';
+
+export async function distillRejections(rejections: RejectionSnapshot[], provider: AIProvider, signal: AbortSignal): Promise<string> {
+    if (!provider.canSummarize || rejections.length === 0) return '';
+
+    const formatted = rejections
+        .map((r, i) => {
+            const tabLines = r.tabs.map(t => `   - "${t.title}" (${t.hostname})`).join('\n');
+            return `${i + 1}. Group "${r.groupName}":\n${tabLines}`;
+        })
+        .join('\n\n');
+
+    const prompt = `The user rejected these proposed tab groupings:\n\n${formatted}\n\nEach rejection means the user did NOT want those tabs grouped that way.\nWrite 1-2 short rules (one sentence each) that capture what the user probably prefers.\nRules must generalize beyond these specific tabs.\nOutput only rules, one per line, starting with "- ".\nIf there is no clear pattern, output nothing.`;
+
+    return (await provider.summarize(prompt, signal)).trim();
+}
+
+async function compressPreferences(allRules: string, provider: AIProvider, signal: AbortSignal): Promise<string> {
+    const prompt = `These are tab grouping preference rules. Compress them to fit within ${LEARNED_PREFERENCES_MAX_LENGTH} characters.\nMerge overlapping rules. Keep the most specific and actionable. Drop vague ones.\nOutput only rules, one per line, starting with "- ".\n\n${allRules}`;
+    return (await provider.summarize(prompt, signal)).trim().slice(0, LEARNED_PREFERENCES_MAX_LENGTH);
+}
+
+/**
+ * Pop pending rejections, distill into rules, update learnedPreferences.
+ * No-op when provider cannot summarize or there are no pending rejections.
+ */
+export async function processDistillation(provider: AIProvider, signal: AbortSignal): Promise<void> {
+    const pending = await popPendingRejections();
+    if (pending.length === 0 || !provider.canSummarize) return;
+
+    const newRules = await distillRejections(pending, provider, signal);
+    if (!newRules) return;
+
+    const existing = await getLearnedPreferences();
+    const combined = existing ? `${existing}\n${newRules}` : newRules;
+
+    if (combined.length <= LEARNED_PREFERENCES_MAX_LENGTH) {
+        await setLearnedPreferences(combined);
+    } else {
+        await setLearnedPreferences(await compressPreferences(combined, provider, signal));
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect pass**
+
+```bash
+npm run test src/utils/__tests__/distillation.test.ts 2>&1 | tail -10
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj commit -m "feat: add distillation service
+
+distillRejections() converts rejection snapshots to preference rules
+via the AI. processDistillation() orchestrates pop → distill → compress
+→ persist, with a 500-char self-compacting budget."
+```
+
+---
+
+## Task 5: Capture rejection snapshots in the background handler
+
+**Files:**
+- Modify: `src/background/index.ts`
+
+- [ ] **Step 1: Update the `DismissSuggestion` handler**
+
+In `src/background/index.ts`, add the import at the top:
+
+```ts
+import { storePendingRejection } from '../utils/rejectionMemory';
+```
+
+Replace the existing `DismissSuggestion` handler block:
+
+```ts
+} else if (msg.type === TabGroupMessageType.DismissSuggestion) {
+    if (msg.windowId && msg.tabIds?.length) {
+        await StateService.removeSuggestionsForTabIds(msg.windowId, msg.tabIds);
+    }
+}
+```
+
+With:
+
+```ts
+} else if (msg.type === TabGroupMessageType.DismissSuggestion) {
+    if (msg.windowId && msg.tabIds?.length) {
+        // Capture rejection snapshot before removing from cache
+        const cacheSamples = await Promise.all(msg.tabIds.map(tid => StateService.getSuggestion(tid, msg.windowId)));
+        const groupName = cacheSamples.find(s => s?.groupName)?.groupName;
+        if (groupName) {
+            const chromeTabs = await Promise.all(msg.tabIds.map(tid => chrome.tabs.get(tid).catch(() => null)));
+            const tabs = chromeTabs
+                .filter((t): t is chrome.tabs.Tab => t !== null)
+                .flatMap(t => {
+                    if (!t.url) return [];
+                    try {
+                        return [{ title: t.title ?? '', hostname: new URL(t.url).hostname }];
+                    } catch {
+                        return [];
+                    }
+                })
+                .filter(t => t.hostname);
+            if (tabs.length > 0) {
+                await storePendingRejection({ groupName, tabs, timestamp: new Date().toISOString() });
+            }
+        }
+        await StateService.removeSuggestionsForTabIds(msg.windowId, msg.tabIds);
+    }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npm run build 2>&1 | grep -E "error TS" | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "feat: capture rejection snapshots on dismiss
+
+Before removing a dismissed suggestion from cache, look up the group
+name and tab hostnames/titles and store a RejectionSnapshot in session
+storage for distillation on the next processing cycle."
+```
+
+---
+
+## Task 6: Integrate distillation into QueueProcessor
+
+**Files:**
+- Modify: `src/background/queueProcessor.ts`
+- Modify: `src/background/__tests__/queueProcessor.test.ts`
+
+- [ ] **Step 1: Update imports in `src/background/queueProcessor.ts`**
+
+Replace:
+```ts
+import { getEffectiveRules } from '../utils/personalization';
+```
+
+With:
+```ts
+import { getEffectiveRules } from '../utils/rejectionMemory';
+import { processDistillation } from '../utils/distillation';
+```
+
+- [ ] **Step 2: Hoist `getEffectiveRules` + add distillation call**
+
+In `QueueProcessor.process()`, after `const settings = await SettingsStorage.get();` and before `const windowIds = this.state.acquireQueue();`, add:
+
+```ts
+// Distill any pending rejections into learned preferences
+try {
+    const provider = await AIService.getProvider(settings);
+    const distillSignal = new AbortController().signal;
+    await processDistillation(provider, distillSignal);
+} catch {
+    // Don't let distillation failure block grouping
+}
+
+// Resolve effective rules once per cycle (not per batch)
+const effectiveRules = await getEffectiveRules(settings);
+```
+
+- [ ] **Step 3: Pass `effectiveRules` into `processWindowBatch`**
+
+Change the call site inside the `for batchTabs of batches` loop:
+```ts
+const result = await this.processWindowBatch(windowId, batchTabs, groupIdManager, settings, effectiveRules);
+```
+
+Update the method signature:
+```ts
+private async processWindowBatch(
+    windowId: number,
+    batchTabs: chrome.tabs.Tab[],
+    groupIdManager: GroupIdManager,
+    settings: AppSettings,
+    effectiveRules: string
+): Promise<{ aborted: boolean }>
+```
+
+Inside `processWindowBatch`, remove:
+```ts
+const effectiveRules = await getEffectiveRules(settings);
+```
+
+The `effectiveRules` parameter is now used directly.
+
+- [ ] **Step 4: Update queueProcessor mock**
+
+In `src/background/__tests__/queueProcessor.test.ts`, add a mock for `distillation`:
+
+```ts
+vi.mock('../../utils/distillation', () => ({
+    processDistillation: vi.fn().mockResolvedValue(undefined)
+}));
+vi.mock('../../utils/rejectionMemory', () => ({
+    getEffectiveRules: vi.fn((s: AppSettings) => Promise.resolve(s.customGroupingRules ?? ''))
+}));
+```
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+npm run test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj commit -m "feat: integrate distillation into QueueProcessor
+
+processDistillation() runs once per cycle before grouping begins.
+getEffectiveRules() is now resolved once per cycle and passed into
+processWindowBatch, fixing the per-batch storage reads."
+```
+
+---
+
+## Task 7: Show learned preferences in options page
+
+**Files:**
+- Modify: `src/options/index.tsx`
+
+- [ ] **Step 1: Add learned preferences state and clear handler**
+
+In `src/options/index.tsx`, add imports:
+
+```ts
+import { getLearnedPreferences, clearLearnedPreferences } from '../utils/rejectionMemory';
+```
+
+Add state after existing state declarations:
+
+```ts
+const [learnedPreferences, setLearnedPreferences] = useState('');
+
+useEffect(() => {
+    getLearnedPreferences().then(setLearnedPreferences);
+}, []);
+```
+
+Add handler:
+```ts
+const handleClearLearnedPreferences = async () => {
+    await clearLearnedPreferences();
+    setLearnedPreferences('');
+};
+```
+
+- [ ] **Step 2: Add read-only learned preferences section in the UI**
+
+After the custom AI instructions textarea block, add:
+
+```tsx
+{learnedPreferences.trim() && (
+    <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle'>
+        <div className='flex items-center justify-between mb-2'>
+            <label className='block font-medium text-main'>What the AI has learned</label>
+            <button
+                type='button'
+                onClick={handleClearLearnedPreferences}
+                className='text-xs text-muted hover:text-status-error-fg transition-colors'
+            >
+                Clear
+            </button>
+        </div>
+        <p className='text-sm text-muted mb-3'>Automatically refined from dismissed suggestions.</p>
+        <pre className='text-xs text-muted whitespace-pre-wrap font-mono bg-surface/50 rounded-xl border border-border-subtle p-3'>{learnedPreferences}</pre>
+    </div>
+)}
+```
+
+- [ ] **Step 3: Build and verify**
+
+```bash
+npm run build 2>&1 | grep -E "error TS" | head -20
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj commit -m "feat: show learned preferences in settings
+
+Read-only section displays what the AI has learned from dismissed
+suggestions, with a Clear button to reset."
+```
+
+---
+
+## Task 8: Fix remaining code review issues
+
+**Files:**
+- Modify: `src/types/toast.ts` — already fixed (`duration: number`)
+- Modify: `src/sidepanel/index.css` — already has the `.suggestion-item-card` CSS
+- Verify `src/utils/groupSuggestionKey.ts` — already extracted
+- Run full build + tests
+
+- [ ] **Step 1: Verify groupSuggestionKey test still passes**
+
+```bash
+npm run test src/utils/__tests__/groupSuggestionKey.test.ts 2>&1 | tail -5
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 2: Full build and test**
+
+```bash
+npm run build && npm run test 2>&1 | tail -20
+```
+
+Expected: build succeeds, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj commit -m "fix: finalize review cleanup
+
+Verified toast duration type fix, CSS suggestion-item-card tokens,
+and groupSuggestionKey extraction all carry forward cleanly."
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lattice",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/src/background/__tests__/queueProcessor.test.ts
+++ b/src/background/__tests__/queueProcessor.test.ts
@@ -35,6 +35,12 @@ vi.mock('../../utils/tabs', async importOriginal => {
 vi.mock('../../utils/tabFilter', () => ({
     isGroupableTab: vi.fn().mockReturnValue(true)
 }));
+vi.mock('../../utils/distillation', () => ({
+    processDistillation: vi.fn().mockResolvedValue(undefined)
+}));
+vi.mock('../../utils/rejectionMemory', () => ({
+    getEffectiveRules: vi.fn((s: AppSettings) => Promise.resolve(s.customGroupingRules ?? ''))
+}));
 
 // ... (rest of imports)
 
@@ -224,7 +230,8 @@ describe('QueueProcessor', () => {
     it('should handle window closed error gracefully', async () => {
         vi.mocked(mockWindows.get).mockRejectedValue(new Error('Window closed'));
         await processor.process();
-        expect(AIService.getProvider).not.toHaveBeenCalled();
+        const provider = await AIService.getProvider({} as AppSettings);
+        expect(provider.generateSuggestions).not.toHaveBeenCalled();
     });
 
     it('should skip non-normal windows', async () => {
@@ -318,8 +325,9 @@ describe('QueueProcessor', () => {
 
         await processor.process();
 
-        // Should not call AI
-        expect(AIService.getProvider).not.toHaveBeenCalled();
+        // Should not call AI for grouping (distillation may still call getProvider)
+        const provider = await AIService.getProvider({} as AppSettings);
+        expect(provider.generateSuggestions).not.toHaveBeenCalled();
         // Should not release (already released by acquireQueue failure)
     });
 
@@ -440,8 +448,9 @@ describe('QueueProcessor', () => {
 
         await processor.process();
 
-        // Should complete the window without calling AI
-        expect(AIService.getProvider).not.toHaveBeenCalled();
+        // Should complete the window without calling AI for grouping
+        const provider = await AIService.getProvider({} as AppSettings);
+        expect(provider.generateSuggestions).not.toHaveBeenCalled();
         expect(mockState.completeWindow).toHaveBeenCalledWith(1);
     });
 

--- a/src/background/__tests__/queueProcessor_batching.test.ts
+++ b/src/background/__tests__/queueProcessor_batching.test.ts
@@ -9,6 +9,12 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 vi.mock('../../utils/storage');
 vi.mock('../../utils/snapshots');
 vi.mock('../../services/ai/AIService');
+vi.mock('../../utils/distillation', () => ({
+    processDistillation: vi.fn().mockResolvedValue(undefined)
+}));
+vi.mock('../../utils/rejectionMemory', () => ({
+    getEffectiveRules: vi.fn().mockResolvedValue('')
+}));
 vi.mock('../../utils/tabs', async importOriginal => {
     const actual = await importOriginal<typeof import('../../utils/tabs')>();
     return { ...actual, applyTabGroup: vi.fn() };

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -64,6 +64,10 @@ chrome.runtime.onConnect.addListener(port => {
                 await StateService.clearWindowSnapshot(msg.windowId); // Force re-process
                 tabManager.triggerRecalculation('Regenerate Request');
             }
+        } else if (msg.type === TabGroupMessageType.DismissSuggestion) {
+            if (msg.windowId && msg.tabIds?.length) {
+                await StateService.removeSuggestionsForTabIds(msg.windowId, msg.tabIds);
+            }
         }
     });
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -5,6 +5,7 @@ import { TabManager } from './tabManager';
 import { TabGroupMessageType } from '../types/tabGrouper';
 import { SettingsStorage } from '../utils/storage';
 import { BadgeService } from '../services/BadgeService';
+import { storePendingRejection } from '../utils/rejectionMemory';
 
 console.log('[Background] Service Worker Initialized');
 StateService.clearProcessingStatus().catch(err => console.error('[Background] Failed to clear processing status', err));
@@ -66,6 +67,26 @@ chrome.runtime.onConnect.addListener(port => {
             }
         } else if (msg.type === TabGroupMessageType.DismissSuggestion) {
             if (msg.windowId && msg.tabIds?.length) {
+                // Capture rejection snapshot before removing from cache
+                const cacheSamples = await Promise.all(msg.tabIds.map((tid: number) => StateService.getSuggestion(tid, msg.windowId)));
+                const groupName = cacheSamples.find(s => s?.groupName)?.groupName;
+                if (groupName) {
+                    const chromeTabs = await Promise.all(msg.tabIds.map((tid: number) => chrome.tabs.get(tid).catch(() => null)));
+                    const tabs = chromeTabs
+                        .filter((t): t is chrome.tabs.Tab => t !== null)
+                        .flatMap(t => {
+                            if (!t.url) return [];
+                            try {
+                                return [{ title: t.title ?? '', hostname: new URL(t.url).hostname }];
+                            } catch {
+                                return [];
+                            }
+                        })
+                        .filter(t => t.hostname);
+                    if (tabs.length > 0) {
+                        await storePendingRejection({ groupName, tabs, timestamp: new Date().toISOString() });
+                    }
+                }
                 await StateService.removeSuggestionsForTabIds(msg.windowId, msg.tabIds);
             }
         }

--- a/src/background/queueProcessor.ts
+++ b/src/background/queueProcessor.ts
@@ -9,6 +9,8 @@ import { getUserFriendlyError } from '../utils/errors';
 import { FeatureId } from '../types/features';
 import { GroupIdManager } from './GroupIdManager';
 import { WindowSnapshot } from '../utils/snapshots';
+import { getEffectiveRules } from '../utils/rejectionMemory';
+import { processDistillation } from '../utils/distillation';
 
 export class QueueProcessor {
     private windowAbortControllers = new Map<number, AbortController>();
@@ -85,6 +87,18 @@ export class QueueProcessor {
             const batchSize = this.getBatchSize(settings);
             console.log(`[QueueProcessor] Using batch size: ${batchSize} for provider: ${settings.aiProvider}`);
 
+            // Distill any pending rejections into learned preferences
+            try {
+                const provider = await AIService.getProvider(settings);
+                const distillSignal = new AbortController().signal;
+                await processDistillation(provider, distillSignal);
+            } catch {
+                // Don't let distillation failure block grouping
+            }
+
+            // Resolve effective rules once per cycle (not per batch)
+            const effectiveRules = await getEffectiveRules(settings);
+
             const windowIds = this.state.acquireQueue() as number[];
             if (windowIds.length === 0) {
                 console.log(`[QueueProcessor] Failed to acquire queue (Busy or Empty)`);
@@ -125,7 +139,7 @@ export class QueueProcessor {
 
                     const groupIdManager = new GroupIdManager();
                     for (const batchTabs of batches) {
-                        const result = await this.processWindowBatch(windowId, batchTabs, groupIdManager, settings);
+                        const result = await this.processWindowBatch(windowId, batchTabs, groupIdManager, settings, effectiveRules);
 
                         if (batches.length > 1) {
                             console.log(`[QueueProcessor] Processed batch ${batches.indexOf(batchTabs) + 1}/${batches.length} for window ${windowId}`);
@@ -150,7 +164,7 @@ export class QueueProcessor {
         }
     }
 
-    private async processWindowBatch(windowId: number, batchTabs: chrome.tabs.Tab[], groupIdManager: GroupIdManager, settings: AppSettings): Promise<{ aborted: boolean }> {
+    private async processWindowBatch(windowId: number, batchTabs: chrome.tabs.Tab[], groupIdManager: GroupIdManager, settings: AppSettings, effectiveRules: string): Promise<{ aborted: boolean }> {
         // Check snapshot before each batch (uses centralized function)
         const windowState = this.state.getWindowState(windowId);
 
@@ -181,7 +195,7 @@ export class QueueProcessor {
                 controller
             });
 
-            const promptInput = windowState.inputSnapshot.getPromptForBatch(batchTabs, groupIdManager.getGroupMap(), settings.customGroupingRules);
+            const promptInput = windowState.inputSnapshot.getPromptForBatch(batchTabs, groupIdManager.getGroupMap(), effectiveRules);
 
             const results = await provider.generateSuggestions({
                 ...promptInput,

--- a/src/background/state.ts
+++ b/src/background/state.ts
@@ -127,6 +127,20 @@ export class StateService {
     }
 
     /**
+     * Remove suggestions for the given tab IDs in a window (e.g. when user rejects a group).
+     */
+    static async removeSuggestionsForTabIds(windowId: number, tabIds: number[]): Promise<void> {
+        await this.hydrate();
+        const windowCache = this.cache?.get(windowId);
+        if (!windowCache) return;
+        let changed = false;
+        for (const tabId of tabIds) {
+            if (windowCache.delete(tabId)) changed = true;
+        }
+        if (changed) await this.persist();
+    }
+
+    /**
      * Remove a suggestion by tab ID (searches all windows)
      */
     static async removeSuggestion(tabId: number): Promise<boolean> {

--- a/src/context/ToastContext.tsx
+++ b/src/context/ToastContext.tsx
@@ -27,9 +27,7 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
             setToasts(prev => [...prev, { id, message, type, duration }]);
 
             if (duration > 0) {
-                setTimeout(() => {
-                    removeToast(id);
-                }, duration);
+                setTimeout(() => removeToast(id), duration);
             }
         },
         [removeToast]
@@ -67,8 +65,8 @@ const ToastContainer: React.FC<ToastContainerProps> = ({ toasts, removeToast }) 
                         {toast.type === 'error' && <AlertCircle className='w-5 h-5' />}
                         {toast.type === 'info' && <Info className='w-5 h-5' />}
                     </div>
-                    <p className='flex-1 text-sm font-medium leading-tight'>{toast.message}</p>
-                    <button onClick={() => removeToast(toast.id)} className='shrink-0 text-current opacity-70 hover:opacity-100 transition-opacity'>
+                    <p className='flex-1 min-w-0 text-sm font-medium leading-tight'>{toast.message}</p>
+                    <button onClick={() => removeToast(toast.id)} className='shrink-0 text-current opacity-70 hover:opacity-100 transition-opacity' aria-label='Dismiss'>
                         <X className='w-4 h-4' />
                     </button>
                 </div>

--- a/src/hooks/useTabGrouper.ts
+++ b/src/hooks/useTabGrouper.ts
@@ -7,6 +7,7 @@ import type { Action } from '../types/suggestions';
 
 import { StateService } from '../background/state';
 import { WindowSnapshot } from '../utils/snapshots';
+import { groupSuggestionKey } from '../utils/groupSuggestionKey';
 export type { TabGroupSuggestion };
 
 export const useTabGrouper = () => {
@@ -64,7 +65,7 @@ export const useTabGrouper = () => {
             // Only include if tab still exists in our snapshot and has a group name
             if (!snap.hasTab(cached.tabId) || !cached.groupName) continue;
 
-            const key = cached.existingGroupId ? `existing-${cached.existingGroupId}` : `new-${cached.groupName}`;
+            const key = groupSuggestionKey(cached.groupName!, cached.existingGroupId);
 
             if (!groupMap.has(key)) {
                 groupMap.set(key, {
@@ -315,6 +316,18 @@ export const useTabGrouper = () => {
         setBackgroundProcessing(true); // Show analyzing state immediately
     }, [currentWindowId]);
 
+    const dismissSuggestion = useCallback(
+        (tabIds: number[]) => {
+            if (!portRef.current || !currentWindowId) return;
+            portRef.current.postMessage({
+                type: TabGroupMessageType.DismissSuggestion,
+                windowId: currentWindowId,
+                tabIds
+            });
+        },
+        [currentWindowId]
+    );
+
     const setAllGroupsSelected = (selected: boolean) => {
         if (!previewGroups) return;
         if (selected) {
@@ -354,6 +367,7 @@ export const useTabGrouper = () => {
         setAllGroupsSelected,
         regenerateSuggestions,
         triggerProcessing,
+        dismissSuggestion,
         aiEnabled,
         newGroupCount
     };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Lattice Tabs - AI Tab Manager",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "AI-powered tab organization with privacy-first design.",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuuxzdViPKnWEdhVlNliZDsj8POg4zb7x3TONSnfzhVBgIdlbF+IMoIeSOvMYFi6aUn1cfCM5l6RJySYUmU6zag5nswLQ1A5GLVT8Br5KGghbanerFT67E7kP7iWjvoiqXhuLAs3/CuzOxKm0pgozU23w3Ai8g/C32wHQEnfCwu90+9GkAonkTzyia+QwKAAak7GoU7mtrZVLhvAxHr6SATs5/w5Hs07Lpt38D6cS7jeK2tFNpCSFKoA18jYN5nETKA2a9Qkyl/RM/n9t1UI232mb7vlmqayjutfaxb0+azgmsLBLruKTyYMwcwiDJH9I72t3RM/WB17QGSy9zLyClwIDAQAB",
     "permissions": ["storage", "tabs", "tabGroups", "alarms"],

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -5,6 +5,7 @@ import { Settings, Save, Sparkles, RefreshCw, Eye, EyeOff, Loader2, AlertCircle 
 import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import { AppSettings, DEFAULT_SETTINGS, SettingsStorage, AIProviderType, DEFAULT_GROUPING_RULES } from '../utils/storage';
+import { getLearnedPreferences, clearLearnedPreferences } from '../utils/rejectionMemory';
 import { FeatureId } from '../types/features';
 import { AIService } from '../services/ai/AIService';
 import { LocalProvider } from '../services/ai/LocalProvider';
@@ -68,6 +69,12 @@ export const InnerApp = () => {
     const [loadingModels, setLoadingModels] = useState(false);
     const [showApiKey, setShowApiKey] = useState(false);
 
+    const [learnedPreferences, setLearnedPreferences] = useState('');
+
+    useEffect(() => {
+        getLearnedPreferences().then(setLearnedPreferences);
+    }, []);
+
     // Download Progress State
     const [isDownloading, setIsDownloading] = useState(false);
     const [downloadProgress, setDownloadProgress] = useState<{
@@ -111,6 +118,11 @@ export const InnerApp = () => {
             }
         });
     }, [fetchModels]);
+
+    const handleClearLearnedPreferences = async () => {
+        await clearLearnedPreferences();
+        setLearnedPreferences('');
+    };
 
     const handleSave = async () => {
         await SettingsStorage.set(settings);
@@ -367,6 +379,22 @@ export const InnerApp = () => {
                                 className='w-full h-32 bg-surface/50 rounded-xl border border-border-subtle p-3 text-sm text-main placeholder:text-muted/50 focus:outline-none focus:ring-2 focus:ring-teal-500/20 transition-all resize-none'
                             />
                         </div>
+                        {learnedPreferences.trim() && (
+                            <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle'>
+                                <div className='flex items-center justify-between mb-2'>
+                                    <label className='block font-medium text-main'>What the AI has learned</label>
+                                    <button
+                                        type='button'
+                                        onClick={handleClearLearnedPreferences}
+                                        className='text-xs text-muted hover:text-status-error-fg transition-colors'
+                                    >
+                                        Clear
+                                    </button>
+                                </div>
+                                <p className='text-sm text-muted mb-3'>Automatically refined from dismissed suggestions.</p>
+                                <pre className='text-xs text-muted whitespace-pre-wrap font-mono bg-surface/50 rounded-xl border border-border-subtle p-3'>{learnedPreferences}</pre>
+                            </div>
+                        )}
                     </div>
 
                     <button

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -369,9 +369,7 @@ export const InnerApp = () => {
 
                         <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle group hover:border-teal-500/30 transition-colors focus-within:border-teal-500/50'>
                             <label className='block font-medium text-main mb-2'>Custom AI Instructions</label>
-                            <p className='text-sm text-muted mb-3'>
-                                Add specific rules for the AI to follow when grouping tabs (e.g., &quot;Group all Jira tickets together&quot;).
-                            </p>
+                            <p className='text-sm text-muted mb-3'>Add specific rules for the AI to follow when grouping tabs (e.g., &quot;Group all Jira tickets together&quot;).</p>
                             <textarea
                                 value={settings.customGroupingRules}
                                 onChange={e => setSettings(s => ({ ...s, customGroupingRules: e.target.value }))}
@@ -383,11 +381,7 @@ export const InnerApp = () => {
                             <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle'>
                                 <div className='flex items-center justify-between mb-2'>
                                     <label className='block font-medium text-main'>What the AI has learned</label>
-                                    <button
-                                        type='button'
-                                        onClick={handleClearLearnedPreferences}
-                                        className='text-xs text-muted hover:text-status-error-fg transition-colors'
-                                    >
+                                    <button type='button' onClick={handleClearLearnedPreferences} className='text-xs text-muted hover:text-status-error-fg transition-colors'>
                                         Clear
                                     </button>
                                 </div>

--- a/src/options/index.tsx
+++ b/src/options/index.tsx
@@ -357,15 +357,12 @@ export const InnerApp = () => {
 
                         <div className='p-4 bg-surface-dim rounded-2xl border border-border-subtle group hover:border-teal-500/30 transition-colors focus-within:border-teal-500/50'>
                             <label className='block font-medium text-main mb-2'>Custom AI Instructions</label>
-                            <p className='text-sm text-muted mb-3'>Add specific rules for the AI to follow when grouping tabs (e.g., "Group all Jira tickets together").</p>
+                            <p className='text-sm text-muted mb-3'>
+                                Add specific rules for the AI to follow when grouping tabs (e.g., &quot;Group all Jira tickets together&quot;).
+                            </p>
                             <textarea
                                 value={settings.customGroupingRules}
-                                onChange={e =>
-                                    setSettings({
-                                        ...settings,
-                                        customGroupingRules: e.target.value
-                                    })
-                                }
+                                onChange={e => setSettings(s => ({ ...s, customGroupingRules: e.target.value }))}
                                 placeholder={DEFAULT_GROUPING_RULES}
                                 className='w-full h-32 bg-surface/50 rounded-xl border border-border-subtle p-3 text-sm text-main placeholder:text-muted/50 focus:outline-none focus:ring-2 focus:ring-teal-500/20 transition-all resize-none'
                             />

--- a/src/services/ai/BaseProvider.ts
+++ b/src/services/ai/BaseProvider.ts
@@ -9,6 +9,8 @@ import { AbortError } from '../../utils/AppError';
  */
 export abstract class BaseProvider implements AIProvider {
     abstract id: string;
+    abstract canSummarize: boolean;
+    abstract summarize(prompt: string, signal: AbortSignal): Promise<string>;
 
     /**
      * Provider-specific method to call the AI with a prompt.

--- a/src/services/ai/GeminiProvider.ts
+++ b/src/services/ai/GeminiProvider.ts
@@ -7,7 +7,7 @@ export class GeminiProvider extends BaseProvider {
     canSummarize = true;
 
     async summarize(prompt: string, signal: AbortSignal): Promise<string> {
-        return this.promptAI(prompt, 'You are a concise assistant helping refine AI tab-grouping rules.', signal);
+        return this.promptAI(prompt, 'You are a concise assistant helping refine AI tab-grouping rules.', signal, true);
     }
 
     protected override get includesGroupTabs(): boolean {
@@ -21,7 +21,7 @@ export class GeminiProvider extends BaseProvider {
         super();
     }
 
-    protected async promptAI(userPrompt: string, systemPrompt: string, signal: AbortSignal): Promise<string> {
+    protected async promptAI(userPrompt: string, systemPrompt: string, signal: AbortSignal, textMode = false): Promise<string> {
         if (!this.apiKey) throw new ConfigurationError('API Key is missing for Gemini Cloud.');
         if (!this.model) throw new ConfigurationError('Please select an AI model in Settings.');
 
@@ -30,14 +30,13 @@ export class GeminiProvider extends BaseProvider {
         const client = new GoogleGenAI({ apiKey: this.apiKey });
         const isGemma = this.model.includes('gemma');
 
-        const config = isGemma
-            ? {}
-            : {
-                  responseMimeType: 'application/json',
-                  systemInstruction: systemPrompt
-              };
+        const config = !textMode && !isGemma
+            ? { responseMimeType: 'application/json', systemInstruction: systemPrompt }
+            : { systemInstruction: systemPrompt };
 
-        const finalUserPrompt = isGemma ? `System Instructions: ${systemPrompt}\n\nIMPORTANT: Output ONLY valid JSON.\n\nUser Request: ${userPrompt}` : userPrompt;
+        const finalUserPrompt = isGemma && !textMode
+            ? `System Instructions: ${systemPrompt}\n\nIMPORTANT: Output ONLY valid JSON.\n\nUser Request: ${userPrompt}`
+            : userPrompt;
 
         console.log(`[GeminiProvider] [${new Date().toISOString()}] Sending request to ${this.model}${isGemma ? ' (Gemma mode)' : ''}`);
 

--- a/src/services/ai/GeminiProvider.ts
+++ b/src/services/ai/GeminiProvider.ts
@@ -30,13 +30,9 @@ export class GeminiProvider extends BaseProvider {
         const client = new GoogleGenAI({ apiKey: this.apiKey });
         const isGemma = this.model.includes('gemma');
 
-        const config = !textMode && !isGemma
-            ? { responseMimeType: 'application/json', systemInstruction: systemPrompt }
-            : { systemInstruction: systemPrompt };
+        const config = !textMode && !isGemma ? { responseMimeType: 'application/json', systemInstruction: systemPrompt } : { systemInstruction: systemPrompt };
 
-        const finalUserPrompt = isGemma && !textMode
-            ? `System Instructions: ${systemPrompt}\n\nIMPORTANT: Output ONLY valid JSON.\n\nUser Request: ${userPrompt}`
-            : userPrompt;
+        const finalUserPrompt = isGemma && !textMode ? `System Instructions: ${systemPrompt}\n\nIMPORTANT: Output ONLY valid JSON.\n\nUser Request: ${userPrompt}` : userPrompt;
 
         console.log(`[GeminiProvider] [${new Date().toISOString()}] Sending request to ${this.model}${isGemma ? ' (Gemma mode)' : ''}`);
 

--- a/src/services/ai/GeminiProvider.ts
+++ b/src/services/ai/GeminiProvider.ts
@@ -4,6 +4,11 @@ import { AIProviderError, ConfigurationError, AbortError } from '../../utils/App
 
 export class GeminiProvider extends BaseProvider {
     id = 'gemini';
+    canSummarize = true;
+
+    async summarize(prompt: string, signal: AbortSignal): Promise<string> {
+        return this.promptAI(prompt, 'You are a concise assistant helping refine AI tab-grouping rules.', signal);
+    }
 
     protected override get includesGroupTabs(): boolean {
         return true;

--- a/src/services/ai/LocalProvider.ts
+++ b/src/services/ai/LocalProvider.ts
@@ -4,6 +4,11 @@ import { AIProviderError, AbortError } from '../../utils/AppError';
 
 export class LocalProvider extends BaseProvider {
     id = 'local';
+    canSummarize = false;
+
+    async summarize(_prompt: string, _signal: AbortSignal): Promise<string> {
+        return '';
+    }
 
     private static cachedSession: LanguageModel | null = null;
     private static cachedSystemPrompt: string | null = null;

--- a/src/services/ai/__tests__/BaseProvider.test.ts
+++ b/src/services/ai/__tests__/BaseProvider.test.ts
@@ -5,6 +5,11 @@ import { TabData } from '../types';
 // Concrete subclass exposing protected method for testing
 class TestBaseProvider extends BaseProvider {
     id = 'test';
+    canSummarize = false;
+
+    async summarize(_prompt: string, _signal: AbortSignal): Promise<string> {
+        return '';
+    }
 
     protected promptAI(): Promise<string> {
         return Promise.resolve('[]');

--- a/src/services/ai/__tests__/GeminiProvider.test.ts
+++ b/src/services/ai/__tests__/GeminiProvider.test.ts
@@ -172,8 +172,9 @@ describe('GeminiProvider', () => {
 
         const callArgs = mockGenerateContent.mock.calls[0][0];
 
-        // Config should be empty for Gemma
-        expect(callArgs.config).toEqual({});
+        // Config should include systemInstruction but no responseMimeType for Gemma
+        expect(callArgs.config).not.toHaveProperty('responseMimeType');
+        expect(callArgs.config).toHaveProperty('systemInstruction');
 
         // System prompt should be injected into user prompt
         const promptText = callArgs.contents[0].parts[0].text;
@@ -222,6 +223,31 @@ describe('GeminiProvider', () => {
             expect(prompt).toBe(`<existing_groups>
 - "Work"
 </existing_groups>`);
+        });
+    });
+
+    describe('summarize', () => {
+        it('canSummarize should be true', () => {
+            expect(provider.canSummarize).toBe(true);
+        });
+
+        it('should return plain text response from AI', async () => {
+            const expectedText = 'Group work tabs together and keep social tabs separate.';
+            mockGenerateContent.mockResolvedValue({ text: expectedText });
+
+            const result = await provider.summarize('Some rules input', new AbortController().signal);
+
+            expect(result).toBe(expectedText);
+        });
+
+        it('should not set responseMimeType in config when in text mode', async () => {
+            mockGenerateContent.mockResolvedValue({ text: 'plain text response' });
+
+            await provider.summarize('Some prompt', new AbortController().signal);
+
+            const callArgs = mockGenerateContent.mock.calls[0][0];
+            expect(callArgs.config).not.toHaveProperty('responseMimeType');
+            expect(callArgs.config).toHaveProperty('systemInstruction');
         });
     });
 

--- a/src/services/ai/__tests__/LocalProvider.test.ts
+++ b/src/services/ai/__tests__/LocalProvider.test.ts
@@ -230,6 +230,17 @@ ${JSON.stringify({ 'Group A': [1, 2] })}`;
             expect(prompt).toContain('</existing_groups>');
         });
     });
+    describe('summarize', () => {
+        it('canSummarize should be false', () => {
+            expect(provider.canSummarize).toBe(false);
+        });
+
+        it('should return empty string', async () => {
+            const result = await provider.summarize('Some rules input', new AbortController().signal);
+            expect(result).toBe('');
+        });
+    });
+
     it('should abort inflight request when signal is triggered', async () => {
         const controller = new AbortController();
         const request: GroupingRequest = {

--- a/src/services/ai/types.ts
+++ b/src/services/ai/types.ts
@@ -32,6 +32,18 @@ export interface AIProvider {
     id: string;
 
     /**
+     * Whether this provider can summarize free-form text.
+     * LocalProvider returns false — Gemini Nano is not reliable for summarization.
+     */
+    canSummarize: boolean;
+
+    /**
+     * Free-form text summarization. Only call when canSummarize is true.
+     * Used for distilling rejection snapshots into preference rules.
+     */
+    summarize(prompt: string, signal: AbortSignal): Promise<string>;
+
+    /**
      * Process a list of tabs and return group assignments.
      * Returns both suggestions and any errors that occurred during processing.
      */

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -14,17 +14,7 @@ interface SuggestionItemProps {
     tabs?: SuggestionTab[];
 }
 
-export const SuggestionItem: React.FC<SuggestionItemProps> = ({
-    title,
-    description,
-    icon: Icon,
-    type,
-    onClick,
-    onDismiss,
-    isLoading,
-    disabled,
-    tabs
-}) => {
+export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, description, icon: Icon, type, onClick, onDismiss, isLoading, disabled, tabs }) => {
     const canReject = !!onDismiss && type === SuggestionType.Group;
 
     const groupedTabs = React.useMemo(() => {
@@ -102,11 +92,7 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({
                 <div className='px-2 pb-2 pl-9 space-y-0.5'>
                     {groupedTabs.map(({ tab, count }, idx) => (
                         <div key={idx} className='flex items-center gap-1.5 min-w-0'>
-                            {tab.favIconUrl ? (
-                                <img src={tab.favIconUrl} className='w-3 h-3 shrink-0 rounded-sm' alt='' />
-                            ) : (
-                                <div className='w-3 h-3 shrink-0 rounded-sm bg-border-subtle' />
-                            )}
+                            {tab.favIconUrl ? <img src={tab.favIconUrl} className='w-3 h-3 shrink-0 rounded-sm' alt='' /> : <div className='w-3 h-3 shrink-0 rounded-sm bg-border-subtle' />}
                             <span className='text-[10px] text-muted truncate leading-tight flex-1'>{tab.title || tab.url}</span>
                             {count > 1 && <span className='text-[10px] text-muted shrink-0 font-medium'>x{count}</span>}
                         </div>

--- a/src/sidepanel/components/SuggestionItem.tsx
+++ b/src/sidepanel/components/SuggestionItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LucideIcon, ArrowRight, Loader2 } from 'lucide-react';
+import { LucideIcon, ArrowRight, Loader2, X } from 'lucide-react';
 import { SuggestionType, SuggestionTab } from '../../types/suggestions';
 
 interface SuggestionItemProps {
@@ -8,28 +8,34 @@ interface SuggestionItemProps {
     icon: LucideIcon;
     type: SuggestionType;
     onClick: () => void;
+    onDismiss?: () => void;
     isLoading?: boolean;
     disabled?: boolean;
     tabs?: SuggestionTab[];
 }
 
-export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, description, icon: Icon, type, onClick, isLoading, disabled, tabs }) => {
-    // Aggregate identical tabs
+export const SuggestionItem: React.FC<SuggestionItemProps> = ({
+    title,
+    description,
+    icon: Icon,
+    type,
+    onClick,
+    onDismiss,
+    isLoading,
+    disabled,
+    tabs
+}) => {
+    const canReject = !!onDismiss && type === SuggestionType.Group;
+
     const groupedTabs = React.useMemo(() => {
         if (!tabs) return [];
         const groups = new Map<string, { count: number; tab: (typeof tabs)[0] }>();
-
         tabs.forEach(tab => {
-            // Create a unique key for grouping (title + favicon)
             const key = `${tab.title || ''}|${tab.favIconUrl || ''}`;
             const existing = groups.get(key);
-            if (existing) {
-                existing.count++;
-            } else {
-                groups.set(key, { count: 1, tab });
-            }
+            if (existing) existing.count++;
+            else groups.set(key, { count: 1, tab });
         });
-
         return Array.from(groups.values());
     }, [tabs]);
 
@@ -42,61 +48,67 @@ export const SuggestionItem: React.FC<SuggestionItemProps> = ({ title, descripti
 
     return (
         <div
+            role='button'
+            tabIndex={disabled || isLoading ? -1 : 0}
             className={`
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
-            ${disabled ? 'opacity-50 pointer-events-none' : 'hover:border-action hover:bg-surface-highlight border-border-subtle'}
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            ${disabled ? 'opacity-50 pointer-events-none' : '[&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight'}
         `}
+            onClick={onClick}
+            onKeyDown={handleKeyDown}
+            aria-label={`${title}: ${description}. Apply suggestion.`}
         >
-            {/* Header / Action Area */}
-            <div
-                role='button'
-                tabIndex={disabled || isLoading ? -1 : 0}
-                className='flex items-center gap-2 p-2 cursor-pointer'
-                onClick={onClick}
-                onKeyDown={handleKeyDown}
-                aria-label={`${title}: ${description}. Apply suggestion.`}
-            >
-                <div
-                    className={`
-                    p-1.5 rounded-md shrink-0
-                    ${type === SuggestionType.Group ? 'bg-indigo-500/10 text-indigo-500' : 'bg-rose-500/10 text-rose-500'}
-                `}
-                >
-                    {isLoading ? <Loader2 className='w-4 h-4 animate-spin' /> : <Icon className='w-4 h-4' />}
+            <div className='flex items-center gap-2 p-2'>
+                <div className='flex flex-1 min-w-0 items-center gap-2'>
+                    <div className={`p-1.5 rounded-md shrink-0 ${type === SuggestionType.Group ? 'bg-indigo-500/10 text-indigo-500' : 'bg-rose-500/10 text-rose-500'}`}>
+                        {isLoading ? <Loader2 className='w-4 h-4 animate-spin' /> : <Icon className='w-4 h-4' />}
+                    </div>
+                    <div className='flex-1 min-w-0'>
+                        <h3 className='font-medium text-main truncate text-sm leading-tight'>{title}</h3>
+                        <p className='text-[10px] text-muted truncate leading-tight'>{description}</p>
+                    </div>
+                    <div
+                        className={`
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        ${isLoading ? 'opacity-0' : ''}
+                    `}
+                    >
+                        <span className='text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap'>
+                            Apply
+                        </span>
+                        {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
+                    </div>
                 </div>
-
-                <div className='flex-1 min-w-0'>
-                    <h3 className='font-medium text-main truncate text-sm leading-tight'>{title}</h3>
-                    <p className='text-[10px] text-muted truncate leading-tight'>{description}</p>
-                </div>
-
-                <div
-                    className={`
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    ${isLoading ? 'opacity-0' : ''}
-                `}
-                >
-                    <span className='text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap'>
-                        Apply
-                    </span>
-                    {!isLoading && <ArrowRight className='w-3.5 h-3.5' />}
-                </div>
+                {canReject && (
+                    <button
+                        type='button'
+                        className='reject-btn p-1.5 rounded-lg text-muted cursor-pointer hover:text-action hover:bg-surface-highlight shrink-0 transition-colors duration-200'
+                        onClick={e => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            onDismiss();
+                        }}
+                        aria-label='Reject suggestion'
+                    >
+                        <X className='w-4 h-4' />
+                    </button>
+                )}
             </div>
-
-            {/* Tab List - Always Visible & Compact */}
             {groupedTabs.length > 0 && (
                 <div className='px-2 pb-2 pl-9 space-y-0.5'>
                     {groupedTabs.map(({ tab, count }, idx) => (
-                        <div key={idx} className='flex items-center gap-2 overflow-hidden opacity-80'>
+                        <div key={idx} className='flex items-center gap-1.5 min-w-0'>
                             {tab.favIconUrl ? (
-                                <img src={tab.favIconUrl} className='w-3 h-3 shrink-0' alt='' onError={e => (e.currentTarget.style.display = 'none')} />
+                                <img src={tab.favIconUrl} className='w-3 h-3 shrink-0 rounded-sm' alt='' />
                             ) : (
-                                <div className='w-2 h-2 rounded-full bg-border-strong shrink-0' />
+                                <div className='w-3 h-3 shrink-0 rounded-sm bg-border-subtle' />
                             )}
-                            <span className='truncate text-[11px] text-muted leading-tight flex-1'>{tab.title || tab.url || 'Untitled'}</span>
-                            {count > 1 && <span className='text-[10px] font-medium text-muted bg-surface-dim px-1.5 py-0.5 rounded-full whitespace-nowrap'>x{count}</span>}
+                            <span className='text-[10px] text-muted truncate leading-tight flex-1'>{tab.title || tab.url}</span>
+                            {count > 1 && <span className='text-[10px] text-muted shrink-0 font-medium'>x{count}</span>}
                         </div>
                     ))}
                 </div>

--- a/src/sidepanel/components/SuggestionList.tsx
+++ b/src/sidepanel/components/SuggestionList.tsx
@@ -4,6 +4,7 @@ import { useTabGrouper } from '../../hooks/useTabGrouper';
 import { useDuplicateCleaner } from '../../hooks/useDuplicateCleaner';
 import { SuggestionItem } from './SuggestionItem';
 import { SuggestionType } from '../../types/suggestions';
+import { groupSuggestionKey } from '../../utils/groupSuggestionKey';
 
 interface UnifiedSuggestion {
     id: string;
@@ -13,10 +14,11 @@ interface UnifiedSuggestion {
     icon: LucideIcon;
     onClick: () => Promise<void>;
     tabs: chrome.tabs.Tab[];
+    tabIds?: number[];
 }
 
 export const SuggestionList: React.FC = () => {
-    const { suggestionActions: groupActions, snapshot, applyGroup, isBackgroundProcessing } = useTabGrouper();
+    const { suggestionActions: groupActions, snapshot, applyGroup, dismissSuggestion, isBackgroundProcessing } = useTabGrouper();
     const { duplicateGroups, suggestionActions: dedupeActions, closeDuplicateGroup } = useDuplicateCleaner();
     const [processingId, setProcessingId] = React.useState<string | null>(null);
     const [isAcceptingAll, setIsAcceptingAll] = React.useState(false);
@@ -39,14 +41,16 @@ export const SuggestionList: React.FC = () => {
             if (action.type !== 'group') return;
             const tabCount = action.tabIds.length;
             const groupTabs = action.tabIds.map(tid => snapshot?.getTabData(tid)).filter((t): t is chrome.tabs.Tab => !!t);
+            const stableId = 'group-' + groupSuggestionKey(action.groupName, action.existingGroupId);
             list.push({
-                id: `group-${index}-${action.groupName}`,
+                id: stableId,
                 type: SuggestionType.Group,
                 title: action.existingGroupId ? `Add to "${action.groupName}"` : `Group "${action.groupName}"`,
                 description: `Organize ${tabCount} tab${tabCount > 1 ? 's' : ''}`,
                 icon: Group,
                 onClick: () => applyGroup(index),
-                tabs: groupTabs
+                tabs: groupTabs,
+                tabIds: action.tabIds
             });
         });
 
@@ -138,13 +142,10 @@ export const SuggestionList: React.FC = () => {
                     icon={item.icon}
                     type={item.type}
                     onClick={() => handleAction(item.id, item.onClick)}
+                    onDismiss={item.tabIds?.length ? () => dismissSuggestion(item.tabIds!) : undefined}
                     isLoading={processingId === item.id}
                     disabled={(processingId !== null && processingId !== item.id) || isAcceptingAll}
-                    tabs={item.tabs.map(t => ({
-                        title: t.title,
-                        url: t.url,
-                        favIconUrl: t.favIconUrl
-                    }))}
+                    tabs={item.tabs.map(t => ({ title: t.title, url: t.url, favIconUrl: t.favIconUrl }))}
                 />
             ))}
         </div>

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -61,5 +61,4 @@ describe('SuggestionItem', () => {
         render(<SuggestionItem {...props} />);
         expect(screen.getByText('x2')).toBeInTheDocument();
     });
-
 });

--- a/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionItem.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SuggestionItem } from '../SuggestionItem';
 import { SuggestionType } from '../../../types/suggestions';
 import { Sparkles } from 'lucide-react';
@@ -24,6 +24,10 @@ describe('SuggestionItem', () => {
             }
         ]
     };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
 
     it('renders correctly', () => {
         const { asFragment } = render(<SuggestionItem {...defaultProps} />);
@@ -57,4 +61,5 @@ describe('SuggestionItem', () => {
         render(<SuggestionItem {...props} />);
         expect(screen.getByText('x2')).toBeInTheDocument();
     });
+
 });

--- a/src/sidepanel/components/__tests__/SuggestionList.test.tsx
+++ b/src/sidepanel/components/__tests__/SuggestionList.test.tsx
@@ -7,7 +7,6 @@ import { useDuplicateCleaner } from '../../../hooks/useDuplicateCleaner';
 // Mock hooks
 vi.mock('../../../hooks/useTabGrouper');
 vi.mock('../../../hooks/useDuplicateCleaner');
-
 describe('SuggestionList', () => {
     const mockApplyGroup = vi.fn();
     const mockCloseDuplicateGroup = vi.fn();

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionItem.test.tsx.snap
@@ -3,128 +3,131 @@
 exports[`SuggestionItem > renders correctly 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
-            hover:border-action hover:bg-surface-highlight border-border-subtle
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            [&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight
         "
+    role="button"
+    tabindex="0"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="0"
+      class="flex items-center gap-2 p-2"
     >
       <div
-        class="
-                    p-1.5 rounded-md shrink-0
-                    bg-indigo-500/10 text-indigo-500
-                "
+        class="flex flex-1 min-w-0 items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sparkles w-4 h-4"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="p-1.5 rounded-md shrink-0 bg-indigo-500/10 text-indigo-500"
         >
-          <path
-            d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-          />
-          <path
-            d="M20 2v4"
-          />
-          <path
-            d="M22 4h-4"
-          />
-          <circle
-            cx="4"
-            cy="20"
-            r="2"
-          />
-        </svg>
-      </div>
-      <div
-        class="flex-1 min-w-0"
-      >
-        <h3
-          class="font-medium text-main truncate text-sm leading-tight"
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-sparkles w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+            />
+            <path
+              d="M20 2v4"
+            />
+            <path
+              d="M22 4h-4"
+            />
+            <circle
+              cx="4"
+              cy="20"
+              r="2"
+            />
+          </svg>
+        </div>
+        <div
+          class="flex-1 min-w-0"
         >
-          Test Suggestion
-        </h3>
-        <p
-          class="text-[10px] text-muted truncate leading-tight"
+          <h3
+            class="font-medium text-main truncate text-sm leading-tight"
+          >
+            Test Suggestion
+          </h3>
+          <p
+            class="text-[10px] text-muted truncate leading-tight"
+          >
+            Test Description
+          </p>
+        </div>
+        <div
+          class="
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        
+                    "
         >
-          Test Description
-        </p>
-      </div>
-      <div
-        class="
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    
-                "
-      >
-        <span
-          class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
-        >
-          Apply
-        </span>
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-arrow-right w-3.5 h-3.5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5 12h14"
-          />
-          <path
-            d="m12 5 7 7-7 7"
-          />
-        </svg>
+          <span
+            class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
+          >
+            Apply
+          </span>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-right w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 12h14"
+            />
+            <path
+              d="m12 5 7 7-7 7"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon1.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 1
         </span>
       </div>
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon2.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 2
         </span>
@@ -137,128 +140,131 @@ exports[`SuggestionItem > renders correctly 1`] = `
 exports[`SuggestionItem > renders disabled state 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
             opacity-50 pointer-events-none
         "
+    role="button"
+    tabindex="-1"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
-        class="
-                    p-1.5 rounded-md shrink-0
-                    bg-indigo-500/10 text-indigo-500
-                "
+        class="flex flex-1 min-w-0 items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sparkles w-4 h-4"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="p-1.5 rounded-md shrink-0 bg-indigo-500/10 text-indigo-500"
         >
-          <path
-            d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-          />
-          <path
-            d="M20 2v4"
-          />
-          <path
-            d="M22 4h-4"
-          />
-          <circle
-            cx="4"
-            cy="20"
-            r="2"
-          />
-        </svg>
-      </div>
-      <div
-        class="flex-1 min-w-0"
-      >
-        <h3
-          class="font-medium text-main truncate text-sm leading-tight"
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-sparkles w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+            />
+            <path
+              d="M20 2v4"
+            />
+            <path
+              d="M22 4h-4"
+            />
+            <circle
+              cx="4"
+              cy="20"
+              r="2"
+            />
+          </svg>
+        </div>
+        <div
+          class="flex-1 min-w-0"
         >
-          Test Suggestion
-        </h3>
-        <p
-          class="text-[10px] text-muted truncate leading-tight"
+          <h3
+            class="font-medium text-main truncate text-sm leading-tight"
+          >
+            Test Suggestion
+          </h3>
+          <p
+            class="text-[10px] text-muted truncate leading-tight"
+          >
+            Test Description
+          </p>
+        </div>
+        <div
+          class="
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        
+                    "
         >
-          Test Description
-        </p>
-      </div>
-      <div
-        class="
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    
-                "
-      >
-        <span
-          class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
-        >
-          Apply
-        </span>
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-arrow-right w-3.5 h-3.5"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M5 12h14"
-          />
-          <path
-            d="m12 5 7 7-7 7"
-          />
-        </svg>
+          <span
+            class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
+          >
+            Apply
+          </span>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-right w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 12h14"
+            />
+            <path
+              d="m12 5 7 7-7 7"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon1.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 1
         </span>
       </div>
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon2.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 2
         </span>
@@ -271,97 +277,100 @@ exports[`SuggestionItem > renders disabled state 1`] = `
 exports[`SuggestionItem > renders loading state 1`] = `
 <DocumentFragment>
   <div
+    aria-label="Test Suggestion: Test Description. Apply suggestion."
     class="
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
-            hover:border-action hover:bg-surface-highlight border-border-subtle
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            [&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight
         "
+    role="button"
+    tabindex="-1"
   >
     <div
-      aria-label="Test Suggestion: Test Description. Apply suggestion."
-      class="flex items-center gap-2 p-2 cursor-pointer"
-      role="button"
-      tabindex="-1"
+      class="flex items-center gap-2 p-2"
     >
       <div
-        class="
-                    p-1.5 rounded-md shrink-0
-                    bg-indigo-500/10 text-indigo-500
-                "
+        class="flex flex-1 min-w-0 items-center gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-loader-circle w-4 h-4 animate-spin"
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="p-1.5 rounded-md shrink-0 bg-indigo-500/10 text-indigo-500"
         >
-          <path
-            d="M21 12a9 9 0 1 1-6.219-8.56"
-          />
-        </svg>
-      </div>
-      <div
-        class="flex-1 min-w-0"
-      >
-        <h3
-          class="font-medium text-main truncate text-sm leading-tight"
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-loader-circle w-4 h-4 animate-spin"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 12a9 9 0 1 1-6.219-8.56"
+            />
+          </svg>
+        </div>
+        <div
+          class="flex-1 min-w-0"
         >
-          Test Suggestion
-        </h3>
-        <p
-          class="text-[10px] text-muted truncate leading-tight"
+          <h3
+            class="font-medium text-main truncate text-sm leading-tight"
+          >
+            Test Suggestion
+          </h3>
+          <p
+            class="text-[10px] text-muted truncate leading-tight"
+          >
+            Test Description
+          </p>
+        </div>
+        <div
+          class="
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        opacity-0
+                    "
         >
-          Test Description
-        </p>
-      </div>
-      <div
-        class="
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    opacity-0
-                "
-      >
-        <span
-          class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
-        >
-          Apply
-        </span>
+          <span
+            class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
+          >
+            Apply
+          </span>
+        </div>
       </div>
     </div>
     <div
       class="px-2 pb-2 pl-9 space-y-0.5"
     >
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon1.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 1
         </span>
       </div>
       <div
-        class="flex items-center gap-2 overflow-hidden opacity-80"
+        class="flex items-center gap-1.5 min-w-0"
       >
         <img
           alt=""
-          class="w-3 h-3 shrink-0"
+          class="w-3 h-3 shrink-0 rounded-sm"
           src="https://example.com/icon2.png"
         />
         <span
-          class="truncate text-[11px] text-muted leading-tight flex-1"
+          class="text-[10px] text-muted truncate leading-tight flex-1"
         >
           Tab 2
         </span>

--- a/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
+++ b/src/sidepanel/components/__tests__/__snapshots__/SuggestionList.test.tsx.snap
@@ -6,113 +6,116 @@ exports[`SuggestionList > renders duplicate suggestions 1`] = `
     class="flex flex-col gap-2 p-3"
   >
     <div
+      aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
       class="
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
-            hover:border-action hover:bg-surface-highlight border-border-subtle
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            [&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight
         "
+      role="button"
+      tabindex="0"
     >
       <div
-        aria-label="Clean "Original": Close 1 duplicate tab. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="flex items-center gap-2 p-2"
       >
         <div
-          class="
-                    p-1.5 rounded-md shrink-0
-                    bg-rose-500/10 text-rose-500
-                "
+          class="flex flex-1 min-w-0 items-center gap-2"
         >
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-trash2 lucide-trash-2 w-4 h-4"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
+          <div
+            class="p-1.5 rounded-md shrink-0 bg-rose-500/10 text-rose-500"
           >
-            <path
-              d="M10 11v6"
-            />
-            <path
-              d="M14 11v6"
-            />
-            <path
-              d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"
-            />
-            <path
-              d="M3 6h18"
-            />
-            <path
-              d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
-            />
-          </svg>
-        </div>
-        <div
-          class="flex-1 min-w-0"
-        >
-          <h3
-            class="font-medium text-main truncate text-sm leading-tight"
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-trash2 lucide-trash-2 w-4 h-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 11v6"
+              />
+              <path
+                d="M14 11v6"
+              />
+              <path
+                d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"
+              />
+              <path
+                d="M3 6h18"
+              />
+              <path
+                d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+              />
+            </svg>
+          </div>
+          <div
+            class="flex-1 min-w-0"
           >
-            Clean "Original"
-          </h3>
-          <p
-            class="text-[10px] text-muted truncate leading-tight"
+            <h3
+              class="font-medium text-main truncate text-sm leading-tight"
+            >
+              Clean "Original"
+            </h3>
+            <p
+              class="text-[10px] text-muted truncate leading-tight"
+            >
+              Close 1 duplicate tab
+            </p>
+          </div>
+          <div
+            class="
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        
+                    "
           >
-            Close 1 duplicate tab
-          </p>
-        </div>
-        <div
-          class="
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    
-                "
-        >
-          <span
-            class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
-          >
-            Apply
-          </span>
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-arrow-right w-3.5 h-3.5"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 12h14"
-            />
-            <path
-              d="m12 5 7 7-7 7"
-            />
-          </svg>
+            <span
+              class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
+            >
+              Apply
+            </span>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-arrow-right w-3.5 h-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 12h14"
+              />
+              <path
+                d="m12 5 7 7-7 7"
+              />
+            </svg>
+          </div>
         </div>
       </div>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >
         <div
-          class="flex items-center gap-2 overflow-hidden opacity-80"
+          class="flex items-center gap-1.5 min-w-0"
         >
           <div
-            class="w-2 h-2 rounded-full bg-border-strong shrink-0"
+            class="w-3 h-3 shrink-0 rounded-sm bg-border-subtle"
           />
           <span
-            class="truncate text-[11px] text-muted leading-tight flex-1"
+            class="text-[10px] text-muted truncate leading-tight flex-1"
           >
             Copy
           </span>
@@ -180,27 +183,123 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
     class="flex flex-col gap-2 p-3"
   >
     <div
+      aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
       class="
-            w-full group relative overflow-hidden
-            bg-surface border rounded-lg transition-all duration-200
-            hover:border-action hover:bg-surface-highlight border-border-subtle
+            suggestion-item-card w-full group relative overflow-hidden cursor-pointer
+            bg-surface border rounded-lg transition-all duration-200 border-border-subtle
+            [&:hover:not(:has(.reject-btn:hover))]:border-action [&:hover:not(:has(.reject-btn:hover))]:bg-surface-highlight
         "
+      role="button"
+      tabindex="0"
     >
       <div
-        aria-label="Group "Work": Organize 2 tabs. Apply suggestion."
-        class="flex items-center gap-2 p-2 cursor-pointer"
-        role="button"
-        tabindex="0"
+        class="flex items-center gap-2 p-2"
       >
         <div
-          class="
-                    p-1.5 rounded-md shrink-0
-                    bg-indigo-500/10 text-indigo-500
-                "
+          class="flex flex-1 min-w-0 items-center gap-2"
+        >
+          <div
+            class="p-1.5 rounded-md shrink-0 bg-indigo-500/10 text-indigo-500"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-group w-4 h-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 7V5c0-1.1.9-2 2-2h2"
+              />
+              <path
+                d="M17 3h2c1.1 0 2 .9 2 2v2"
+              />
+              <path
+                d="M21 17v2c0 1.1-.9 2-2 2h-2"
+              />
+              <path
+                d="M7 21H5c-1.1 0-2-.9-2-2v-2"
+              />
+              <rect
+                height="5"
+                rx="1"
+                width="7"
+                x="7"
+                y="7"
+              />
+              <rect
+                height="5"
+                rx="1"
+                width="7"
+                x="10"
+                y="12"
+              />
+            </svg>
+          </div>
+          <div
+            class="flex-1 min-w-0"
+          >
+            <h3
+              class="font-medium text-main truncate text-sm leading-tight"
+            >
+              Group "Work"
+            </h3>
+            <p
+              class="text-[10px] text-muted truncate leading-tight"
+            >
+              Organize 2 tabs
+            </p>
+          </div>
+          <div
+            class="
+                        apply-pill flex items-center gap-1.5 px-2 py-1 rounded-full
+                        text-muted group-hover:text-action group-hover:bg-action/10
+                        transition-opacity duration-300
+                        group-has-[.reject-btn:hover]:opacity-0
+                        
+                    "
+          >
+            <span
+              class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
+            >
+              Apply
+            </span>
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-arrow-right w-3.5 h-3.5"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M5 12h14"
+              />
+              <path
+                d="m12 5 7 7-7 7"
+              />
+            </svg>
+          </div>
+        </div>
+        <button
+          aria-label="Reject suggestion"
+          class="reject-btn p-1.5 rounded-lg text-muted cursor-pointer hover:text-action hover:bg-surface-highlight shrink-0 transition-colors duration-200"
+          type="button"
         >
           <svg
             aria-hidden="true"
-            class="lucide lucide-group w-4 h-4"
+            class="lucide lucide-x w-4 h-4"
             fill="none"
             height="24"
             stroke="currentColor"
@@ -212,104 +311,37 @@ exports[`SuggestionList > renders grouping suggestions 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <path
-              d="M3 7V5c0-1.1.9-2 2-2h2"
+              d="M18 6 6 18"
             />
             <path
-              d="M17 3h2c1.1 0 2 .9 2 2v2"
-            />
-            <path
-              d="M21 17v2c0 1.1-.9 2-2 2h-2"
-            />
-            <path
-              d="M7 21H5c-1.1 0-2-.9-2-2v-2"
-            />
-            <rect
-              height="5"
-              rx="1"
-              width="7"
-              x="7"
-              y="7"
-            />
-            <rect
-              height="5"
-              rx="1"
-              width="7"
-              x="10"
-              y="12"
+              d="m6 6 12 12"
             />
           </svg>
-        </div>
-        <div
-          class="flex-1 min-w-0"
-        >
-          <h3
-            class="font-medium text-main truncate text-sm leading-tight"
-          >
-            Group "Work"
-          </h3>
-          <p
-            class="text-[10px] text-muted truncate leading-tight"
-          >
-            Organize 2 tabs
-          </p>
-        </div>
-        <div
-          class="
-                    flex items-center gap-1.5 px-2 py-1 rounded-full transition-all duration-200
-                    text-muted group-hover:text-action group-hover:bg-action/10
-                    
-                "
-        >
-          <span
-            class="text-[10px] font-semibold uppercase tracking-wide opacity-0 w-0 group-hover:w-auto group-hover:opacity-100 transition-all duration-200 overflow-hidden whitespace-nowrap"
-          >
-            Apply
-          </span>
-          <svg
-            aria-hidden="true"
-            class="lucide lucide-arrow-right w-3.5 h-3.5"
-            fill="none"
-            height="24"
-            stroke="currentColor"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 12h14"
-            />
-            <path
-              d="m12 5 7 7-7 7"
-            />
-          </svg>
-        </div>
+        </button>
       </div>
       <div
         class="px-2 pb-2 pl-9 space-y-0.5"
       >
         <div
-          class="flex items-center gap-2 overflow-hidden opacity-80"
+          class="flex items-center gap-1.5 min-w-0"
         >
           <div
-            class="w-2 h-2 rounded-full bg-border-strong shrink-0"
+            class="w-3 h-3 shrink-0 rounded-sm bg-border-subtle"
           />
           <span
-            class="truncate text-[11px] text-muted leading-tight flex-1"
+            class="text-[10px] text-muted truncate leading-tight flex-1"
           >
             Tab 1
           </span>
         </div>
         <div
-          class="flex items-center gap-2 overflow-hidden opacity-80"
+          class="flex items-center gap-1.5 min-w-0"
         >
           <div
-            class="w-2 h-2 rounded-full bg-border-strong shrink-0"
+            class="w-3 h-3 shrink-0 rounded-sm bg-border-subtle"
           />
           <span
-            class="truncate text-[11px] text-muted leading-tight flex-1"
+            class="text-[10px] text-muted truncate leading-tight flex-1"
           >
             Tab 2
           </span>

--- a/src/sidepanel/index.css
+++ b/src/sidepanel/index.css
@@ -252,3 +252,8 @@ body {
     padding: 0;
     overflow-x: hidden;
 }
+
+/* Suggestion card: hide Apply pill when reject (X) is hovered — :has() fallback for group-has */
+.suggestion-item-card:has(.reject-btn:hover) .apply-pill {
+    opacity: 0;
+}

--- a/src/types/rejection.ts
+++ b/src/types/rejection.ts
@@ -1,0 +1,8 @@
+export interface RejectionSnapshot {
+    /** Group name the AI proposed */
+    groupName: string;
+    /** Tab titles + hostnames only — no full URLs */
+    tabs: { title: string; hostname: string }[];
+    /** ISO timestamp */
+    timestamp: string;
+}

--- a/src/types/tabGrouper.ts
+++ b/src/types/tabGrouper.ts
@@ -15,12 +15,15 @@ export interface TabSuggestionCache {
 
 export enum TabGroupMessageType {
     TriggerProcessing = 'TRIGGER_PROCESSING',
-    RegenerateSuggestions = 'REGENERATE_SUGGESTIONS'
+    RegenerateSuggestions = 'REGENERATE_SUGGESTIONS',
+    DismissSuggestion = 'DISMISS_SUGGESTION'
 }
 
 export interface TabGroupMessage {
     type: TabGroupMessageType;
     windowId?: number;
+    /** For DismissSuggestion: tab IDs of the rejected group */
+    tabIds?: number[];
 }
 
 export interface GroupingContext {

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -4,5 +4,5 @@ export interface Toast {
     id: string;
     message: string;
     type: ToastType;
-    duration?: number;
+    duration: number;
 }

--- a/src/utils/__tests__/distillation.test.ts
+++ b/src/utils/__tests__/distillation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { distillRejections, processDistillation } from '../distillation';
+import type { RejectionSnapshot } from '../../types/rejection';
+import type { AIProvider } from '../../services/ai/types';
+
+vi.mock('../rejectionMemory', () => ({
+    popPendingRejections: vi.fn(),
+    getLearnedPreferences: vi.fn().mockResolvedValue(''),
+    setLearnedPreferences: vi.fn(),
+    LEARNED_PREFERENCES_MAX_LENGTH: 500
+}));
+
+import { popPendingRejections, getLearnedPreferences, setLearnedPreferences } from '../rejectionMemory';
+
+const makeProvider = (canSummarize: boolean, response = ''): AIProvider => ({
+    id: 'test',
+    canSummarize,
+    summarize: vi.fn().mockResolvedValue(response),
+    generateSuggestions: vi.fn() as AIProvider['generateSuggestions']
+});
+
+const snap: RejectionSnapshot = {
+    groupName: 'Work',
+    tabs: [
+        { title: 'PR #45', hostname: 'github.com' },
+        { title: 'useEffect docs', hostname: 'react.dev' }
+    ],
+    timestamp: '2026-01-01T00:00:00.000Z'
+};
+
+const signal = new AbortController().signal;
+
+describe('distillRejections', () => {
+    it('returns empty string for local provider', async () => {
+        const provider = makeProvider(false);
+        expect(await distillRejections([snap], provider, signal)).toBe('');
+    });
+
+    it('returns empty string for empty rejections', async () => {
+        const provider = makeProvider(true, '- Some rule.');
+        expect(await distillRejections([], provider, signal)).toBe('');
+    });
+
+    it('calls summarize with formatted prompt and returns trimmed result', async () => {
+        const provider = makeProvider(true, '  - Keep PRs separate from docs.  ');
+        const result = await distillRejections([snap], provider, signal);
+        expect(result).toBe('- Keep PRs separate from docs.');
+        expect(provider.summarize).toHaveBeenCalledWith(expect.stringContaining('Group "Work"'), signal);
+        expect(provider.summarize).toHaveBeenCalledWith(expect.stringContaining('github.com'), signal);
+    });
+});
+
+describe('processDistillation', () => {
+    beforeEach(() => {
+        vi.mocked(popPendingRejections).mockResolvedValue([snap]);
+        vi.mocked(getLearnedPreferences).mockResolvedValue('');
+        vi.mocked(setLearnedPreferences).mockResolvedValue(undefined);
+    });
+
+    it('does nothing when no pending rejections', async () => {
+        vi.mocked(popPendingRejections).mockResolvedValue([]);
+        const provider = makeProvider(true, '- A rule.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when provider cannot summarize', async () => {
+        const provider = makeProvider(false);
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).not.toHaveBeenCalled();
+    });
+
+    it('stores new rules when under budget', async () => {
+        const provider = makeProvider(true, '- Keep PRs separate from docs.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Keep PRs separate from docs.');
+    });
+
+    it('appends to existing preferences when combined is under budget', async () => {
+        vi.mocked(getLearnedPreferences).mockResolvedValue('- Existing rule.');
+        const provider = makeProvider(true, '- New rule.');
+        await processDistillation(provider, signal);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Existing rule.\n- New rule.');
+    });
+
+    it('compresses when combined exceeds budget', async () => {
+        const longExisting = '- ' + 'x'.repeat(490);
+        vi.mocked(getLearnedPreferences).mockResolvedValue(longExisting);
+        const provider = makeProvider(true, '- New rule.');
+        (provider.summarize as ReturnType<typeof vi.fn>)
+            .mockResolvedValueOnce('- New rule.')      // distill call
+            .mockResolvedValueOnce('- Compressed.');   // compress call
+        await processDistillation(provider, signal);
+        expect(provider.summarize).toHaveBeenCalledTimes(2);
+        expect(setLearnedPreferences).toHaveBeenCalledWith('- Compressed.');
+    });
+});

--- a/src/utils/__tests__/distillation.test.ts
+++ b/src/utils/__tests__/distillation.test.ts
@@ -90,8 +90,8 @@ describe('processDistillation', () => {
         vi.mocked(getLearnedPreferences).mockResolvedValue(longExisting);
         const provider = makeProvider(true, '- New rule.');
         (provider.summarize as ReturnType<typeof vi.fn>)
-            .mockResolvedValueOnce('- New rule.')      // distill call
-            .mockResolvedValueOnce('- Compressed.');   // compress call
+            .mockResolvedValueOnce('- New rule.') // distill call
+            .mockResolvedValueOnce('- Compressed.'); // compress call
         await processDistillation(provider, signal);
         expect(provider.summarize).toHaveBeenCalledTimes(2);
         expect(setLearnedPreferences).toHaveBeenCalledWith('- Compressed.');

--- a/src/utils/__tests__/distillation.test.ts
+++ b/src/utils/__tests__/distillation.test.ts
@@ -52,6 +52,7 @@ describe('distillRejections', () => {
 
 describe('processDistillation', () => {
     beforeEach(() => {
+        vi.clearAllMocks();
         vi.mocked(popPendingRejections).mockResolvedValue([snap]);
         vi.mocked(getLearnedPreferences).mockResolvedValue('');
         vi.mocked(setLearnedPreferences).mockResolvedValue(undefined);
@@ -67,6 +68,7 @@ describe('processDistillation', () => {
     it('does nothing when provider cannot summarize', async () => {
         const provider = makeProvider(false);
         await processDistillation(provider, signal);
+        expect(popPendingRejections).not.toHaveBeenCalled();
         expect(setLearnedPreferences).not.toHaveBeenCalled();
     });
 

--- a/src/utils/__tests__/groupSuggestionKey.test.ts
+++ b/src/utils/__tests__/groupSuggestionKey.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { groupSuggestionKey } from '../groupSuggestionKey';
+
+describe('groupSuggestionKey', () => {
+    it('groupSuggestionCacheKey uses existing id when set', () => {
+        expect(groupSuggestionKey('Work', 42)).toBe('existing-42');
+    });
+
+    it('groupSuggestionCacheKey uses new name when no existing id', () => {
+        expect(groupSuggestionKey('Work', null)).toBe('new-Work');
+        expect(groupSuggestionKey('Work', undefined)).toBe('new-Work');
+    });
+});

--- a/src/utils/__tests__/rejectionMemory.test.ts
+++ b/src/utils/__tests__/rejectionMemory.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { storePendingRejection, popPendingRejections, getLearnedPreferences, setLearnedPreferences, clearLearnedPreferences, getEffectiveRules, LEARNED_PREFERENCES_MAX_LENGTH } from '../rejectionMemory';
+import {
+    storePendingRejection,
+    popPendingRejections,
+    getLearnedPreferences,
+    setLearnedPreferences,
+    clearLearnedPreferences,
+    getEffectiveRules,
+    LEARNED_PREFERENCES_MAX_LENGTH
+} from '../rejectionMemory';
 import type { RejectionSnapshot } from '../../types/rejection';
 import { DEFAULT_GROUPING_RULES } from '../storage';
 import type { AppSettings } from '../storage';

--- a/src/utils/__tests__/rejectionMemory.test.ts
+++ b/src/utils/__tests__/rejectionMemory.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { storePendingRejection, popPendingRejections, getLearnedPreferences, setLearnedPreferences, clearLearnedPreferences, getEffectiveRules } from '../rejectionMemory';
+import type { RejectionSnapshot } from '../../types/rejection';
+import { DEFAULT_GROUPING_RULES } from '../storage';
+import type { AppSettings } from '../storage';
+
+const mockSessionGet = vi.fn();
+const mockSessionSet = vi.fn();
+const mockSessionRemove = vi.fn();
+const mockLocalGet = vi.fn();
+const mockLocalSet = vi.fn();
+const mockLocalRemove = vi.fn();
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionGet.mockResolvedValue({});
+    mockSessionSet.mockResolvedValue(undefined);
+    mockSessionRemove.mockResolvedValue(undefined);
+    mockLocalGet.mockResolvedValue({});
+    mockLocalSet.mockResolvedValue(undefined);
+    mockLocalRemove.mockResolvedValue(undefined);
+    const g = global as unknown as { chrome: unknown };
+    g.chrome = {
+        storage: {
+            session: { get: mockSessionGet, set: mockSessionSet, remove: mockSessionRemove },
+            local: { get: mockLocalGet, set: mockLocalSet, remove: mockLocalRemove }
+        }
+    };
+});
+
+const snap: RejectionSnapshot = {
+    groupName: 'Work',
+    tabs: [{ title: 'PR #1', hostname: 'github.com' }],
+    timestamp: '2026-01-01T00:00:00.000Z'
+};
+
+describe('storePendingRejection', () => {
+    it('appends to empty list', async () => {
+        mockSessionGet.mockResolvedValue({ pendingRejections: [] });
+        await storePendingRejection(snap);
+        expect(mockSessionSet).toHaveBeenCalledWith({ pendingRejections: [snap] });
+    });
+
+    it('prunes to max 20', async () => {
+        const existing = Array.from({ length: 20 }, (_, i) => ({ ...snap, groupName: `G${i}` }));
+        mockSessionGet.mockResolvedValue({ pendingRejections: existing });
+        await storePendingRejection(snap);
+        const saved = mockSessionSet.mock.calls[0][0].pendingRejections as RejectionSnapshot[];
+        expect(saved.length).toBe(20);
+        expect(saved[saved.length - 1]?.groupName).toBe('Work');
+    });
+});
+
+describe('popPendingRejections', () => {
+    it('returns list and removes from storage', async () => {
+        mockSessionGet.mockResolvedValue({ pendingRejections: [snap] });
+        const result = await popPendingRejections();
+        expect(result).toEqual([snap]);
+        expect(mockSessionRemove).toHaveBeenCalledWith('pendingRejections');
+    });
+
+    it('returns empty array when nothing stored', async () => {
+        const result = await popPendingRejections();
+        expect(result).toEqual([]);
+        expect(mockSessionRemove).not.toHaveBeenCalled();
+    });
+});
+
+describe('getLearnedPreferences / setLearnedPreferences / clearLearnedPreferences', () => {
+    it('returns empty string by default', async () => {
+        expect(await getLearnedPreferences()).toBe('');
+    });
+
+    it('round-trips through set/get', async () => {
+        mockLocalGet.mockResolvedValue({ learnedPreferences: '- Keep code separate from docs.' });
+        expect(await getLearnedPreferences()).toBe('- Keep code separate from docs.');
+    });
+
+    it('clearLearnedPreferences removes the key', async () => {
+        await clearLearnedPreferences();
+        expect(mockLocalRemove).toHaveBeenCalledWith('learnedPreferences');
+    });
+});
+
+describe('getEffectiveRules', () => {
+    it('returns default rules when customGroupingRules is empty and no learned prefs', async () => {
+        const settings = { customGroupingRules: '' } as AppSettings;
+        expect(await getEffectiveRules(settings)).toBe(DEFAULT_GROUPING_RULES);
+    });
+
+    it('returns custom rules when set', async () => {
+        const settings = { customGroupingRules: 'My rules.' } as AppSettings;
+        expect(await getEffectiveRules(settings)).toBe('My rules.');
+    });
+
+    it('appends learned preferences when present', async () => {
+        mockLocalGet.mockResolvedValue({ learnedPreferences: '- No mixing docs with PRs.' });
+        const settings = { customGroupingRules: 'My rules.' } as AppSettings;
+        const result = await getEffectiveRules(settings);
+        expect(result).toContain('My rules.');
+        expect(result).toContain('## Learned from your usage');
+        expect(result).toContain('- No mixing docs with PRs.');
+    });
+});

--- a/src/utils/__tests__/rejectionMemory.test.ts
+++ b/src/utils/__tests__/rejectionMemory.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { storePendingRejection, popPendingRejections, getLearnedPreferences, setLearnedPreferences, clearLearnedPreferences, getEffectiveRules } from '../rejectionMemory';
+import { storePendingRejection, popPendingRejections, getLearnedPreferences, setLearnedPreferences, clearLearnedPreferences, getEffectiveRules, LEARNED_PREFERENCES_MAX_LENGTH } from '../rejectionMemory';
 import type { RejectionSnapshot } from '../../types/rejection';
 import { DEFAULT_GROUPING_RULES } from '../storage';
 import type { AppSettings } from '../storage';
@@ -79,6 +79,12 @@ describe('getLearnedPreferences / setLearnedPreferences / clearLearnedPreference
     it('clearLearnedPreferences removes the key', async () => {
         await clearLearnedPreferences();
         expect(mockLocalRemove).toHaveBeenCalledWith('learnedPreferences');
+    });
+});
+
+describe('constants', () => {
+    it('LEARNED_PREFERENCES_MAX_LENGTH equals 500', () => {
+        expect(LEARNED_PREFERENCES_MAX_LENGTH).toBe(500);
     });
 });
 

--- a/src/utils/__tests__/rejectionMemory.test.ts
+++ b/src/utils/__tests__/rejectionMemory.test.ts
@@ -76,6 +76,11 @@ describe('getLearnedPreferences / setLearnedPreferences / clearLearnedPreference
         expect(await getLearnedPreferences()).toBe('- Keep code separate from docs.');
     });
 
+    it('calls storage.local.set with the given value', async () => {
+        await setLearnedPreferences('- Keep work separate.');
+        expect(mockLocalSet).toHaveBeenCalledWith({ learnedPreferences: '- Keep work separate.' });
+    });
+
     it('clearLearnedPreferences removes the key', async () => {
         await clearLearnedPreferences();
         expect(mockLocalRemove).toHaveBeenCalledWith('learnedPreferences');

--- a/src/utils/distillation.ts
+++ b/src/utils/distillation.ts
@@ -27,8 +27,9 @@ async function compressPreferences(allRules: string, provider: AIProvider, signa
  * No-op when provider cannot summarize or there are no pending rejections.
  */
 export async function processDistillation(provider: AIProvider, signal: AbortSignal): Promise<void> {
+    if (!provider.canSummarize) return;
     const pending = await popPendingRejections();
-    if (pending.length === 0 || !provider.canSummarize) return;
+    if (pending.length === 0) return;
 
     const newRules = await distillRejections(pending, provider, signal);
     if (!newRules) return;

--- a/src/utils/distillation.ts
+++ b/src/utils/distillation.ts
@@ -1,0 +1,44 @@
+import type { RejectionSnapshot } from '../types/rejection';
+import type { AIProvider } from '../services/ai/types';
+import { popPendingRejections, getLearnedPreferences, setLearnedPreferences, LEARNED_PREFERENCES_MAX_LENGTH } from './rejectionMemory';
+
+export async function distillRejections(rejections: RejectionSnapshot[], provider: AIProvider, signal: AbortSignal): Promise<string> {
+    if (!provider.canSummarize || rejections.length === 0) return '';
+
+    const formatted = rejections
+        .map((r, i) => {
+            const tabLines = r.tabs.map(t => `   - "${t.title}" (${t.hostname})`).join('\n');
+            return `${i + 1}. Group "${r.groupName}":\n${tabLines}`;
+        })
+        .join('\n\n');
+
+    const prompt = `The user rejected these proposed tab groupings:\n\n${formatted}\n\nEach rejection means the user did NOT want those tabs grouped that way.\nWrite 1-2 short rules (one sentence each) that capture what the user probably prefers.\nRules must generalize beyond these specific tabs.\nOutput only rules, one per line, starting with "- ".\nIf there is no clear pattern, output nothing.`;
+
+    return (await provider.summarize(prompt, signal)).trim();
+}
+
+async function compressPreferences(allRules: string, provider: AIProvider, signal: AbortSignal): Promise<string> {
+    const prompt = `These are tab grouping preference rules. Compress them to fit within ${LEARNED_PREFERENCES_MAX_LENGTH} characters.\nMerge overlapping rules. Keep the most specific and actionable. Drop vague ones.\nOutput only rules, one per line, starting with "- ".\n\n${allRules}`;
+    return (await provider.summarize(prompt, signal)).trim().slice(0, LEARNED_PREFERENCES_MAX_LENGTH);
+}
+
+/**
+ * Pop pending rejections, distill into rules, update learnedPreferences.
+ * No-op when provider cannot summarize or there are no pending rejections.
+ */
+export async function processDistillation(provider: AIProvider, signal: AbortSignal): Promise<void> {
+    const pending = await popPendingRejections();
+    if (pending.length === 0 || !provider.canSummarize) return;
+
+    const newRules = await distillRejections(pending, provider, signal);
+    if (!newRules) return;
+
+    const existing = await getLearnedPreferences();
+    const combined = existing ? `${existing}\n${newRules}` : newRules;
+
+    if (combined.length <= LEARNED_PREFERENCES_MAX_LENGTH) {
+        await setLearnedPreferences(combined);
+    } else {
+        await setLearnedPreferences(await compressPreferences(combined, provider, signal));
+    }
+}

--- a/src/utils/groupSuggestionKey.ts
+++ b/src/utils/groupSuggestionKey.ts
@@ -1,0 +1,9 @@
+/**
+ * Keys for merging cached tab suggestions into preview groups (see useTabGrouper.convertCacheToGroups)
+ * and for stable React row ids in SuggestionList — must stay in sync.
+ */
+
+/** Internal map key: one bucket per new group name or per existing Chrome tab group id. */
+export function groupSuggestionKey(groupName: string, existingGroupId: number | null | undefined): string {
+    return existingGroupId != null ? `existing-${existingGroupId}` : `new-${groupName}`;
+}

--- a/src/utils/rejectionMemory.ts
+++ b/src/utils/rejectionMemory.ts
@@ -1,0 +1,47 @@
+import type { RejectionSnapshot } from '../types/rejection';
+import type { AppSettings } from './storage';
+import { DEFAULT_GROUPING_RULES } from './storage';
+
+const PENDING_REJECTIONS_KEY = 'pendingRejections';
+const LEARNED_PREFERENCES_KEY = 'learnedPreferences';
+const MAX_PENDING = 20;
+export const LEARNED_PREFERENCES_MAX_LENGTH = 500;
+
+export async function storePendingRejection(snapshot: RejectionSnapshot): Promise<void> {
+    const result = await chrome.storage.session.get(PENDING_REJECTIONS_KEY);
+    const list: RejectionSnapshot[] = Array.isArray(result[PENDING_REJECTIONS_KEY]) ? result[PENDING_REJECTIONS_KEY] : [];
+    list.push(snapshot);
+    await chrome.storage.session.set({ [PENDING_REJECTIONS_KEY]: list.slice(-MAX_PENDING) });
+}
+
+export async function popPendingRejections(): Promise<RejectionSnapshot[]> {
+    const result = await chrome.storage.session.get(PENDING_REJECTIONS_KEY);
+    const list: RejectionSnapshot[] = Array.isArray(result[PENDING_REJECTIONS_KEY]) ? result[PENDING_REJECTIONS_KEY] : [];
+    if (list.length > 0) {
+        await chrome.storage.session.remove(PENDING_REJECTIONS_KEY);
+    }
+    return list;
+}
+
+export async function getLearnedPreferences(): Promise<string> {
+    const result = await chrome.storage.local.get(LEARNED_PREFERENCES_KEY);
+    const raw = result[LEARNED_PREFERENCES_KEY];
+    return typeof raw === 'string' ? raw : '';
+}
+
+export async function setLearnedPreferences(prefs: string): Promise<void> {
+    await chrome.storage.local.set({ [LEARNED_PREFERENCES_KEY]: prefs });
+}
+
+export async function clearLearnedPreferences(): Promise<void> {
+    await chrome.storage.local.remove(LEARNED_PREFERENCES_KEY);
+}
+
+export async function getEffectiveRules(settings: AppSettings): Promise<string> {
+    const baseRules = settings.customGroupingRules?.trim() || DEFAULT_GROUPING_RULES;
+    const learned = await getLearnedPreferences();
+    if (learned.trim()) {
+        return `${baseRules}\n\n## Learned from your usage\n${learned.trim()}`;
+    }
+    return baseRules;
+}

--- a/tests/screenshots/popup.spec.ts
+++ b/tests/screenshots/popup.spec.ts
@@ -124,30 +124,4 @@ test.describe('Popup', () => {
             await expect(page).toHaveScreenshot('popup-with-suggestions.png');
         });
     });
-
-    test.describe('Feedback', () => {
-        test.beforeEach(async ({ page }) => {
-            await page.addInitScript(chromeMockScript);
-            await page.addInitScript(completedOnboardingScript);
-            await page.addInitScript(suggestionsMockScript);
-            await page.goto('/src/sidepanel/');
-            await page.waitForSelector('text=Group "Work"', { timeout: 15000 });
-        });
-
-        test('inline feedback — reason buttons after dismissing a suggestion', async ({ page }) => {
-            await page.getByRole('button', { name: 'Reject suggestion' }).first().click();
-            await page.waitForSelector('text=Why did you dismiss?', { timeout: 5000 });
-            await setViewportToContent(page);
-            await expect(page).toHaveScreenshot('popup-feedback-reasons.png');
-        });
-
-        test('inline feedback — Other with optional free-form input', async ({ page }) => {
-            await page.getByRole('button', { name: 'Reject suggestion' }).first().click();
-            await page.waitForSelector('text=Why did you dismiss?', { timeout: 5000 });
-            await page.getByRole('button', { name: 'Other' }).click();
-            await page.waitForSelector('text=Add details (optional)', { timeout: 3000 });
-            await setViewportToContent(page);
-            await expect(page).toHaveScreenshot('popup-feedback-other-input.png');
-        });
-    });
 });

--- a/tests/screenshots/popup.spec.ts
+++ b/tests/screenshots/popup.spec.ts
@@ -124,4 +124,30 @@ test.describe('Popup', () => {
             await expect(page).toHaveScreenshot('popup-with-suggestions.png');
         });
     });
+
+    test.describe('Feedback', () => {
+        test.beforeEach(async ({ page }) => {
+            await page.addInitScript(chromeMockScript);
+            await page.addInitScript(completedOnboardingScript);
+            await page.addInitScript(suggestionsMockScript);
+            await page.goto('/src/sidepanel/');
+            await page.waitForSelector('text=Group "Work"', { timeout: 15000 });
+        });
+
+        test('inline feedback — reason buttons after dismissing a suggestion', async ({ page }) => {
+            await page.getByRole('button', { name: 'Reject suggestion' }).first().click();
+            await page.waitForSelector('text=Why did you dismiss?', { timeout: 5000 });
+            await setViewportToContent(page);
+            await expect(page).toHaveScreenshot('popup-feedback-reasons.png');
+        });
+
+        test('inline feedback — Other with optional free-form input', async ({ page }) => {
+            await page.getByRole('button', { name: 'Reject suggestion' }).first().click();
+            await page.waitForSelector('text=Why did you dismiss?', { timeout: 5000 });
+            await page.getByRole('button', { name: 'Other' }).click();
+            await page.waitForSelector('text=Add details (optional)', { timeout: 3000 });
+            await setViewportToContent(page);
+            await expect(page).toHaveScreenshot('popup-feedback-other-input.png');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- Dismissing a suggestion captures a `RejectionSnapshot` (group name + tab titles/hostnames) in session storage — no forms, no reason codes
- At the start of each AI processing cycle, pending rejections are distilled by Gemini into short generalized preference rules stored in `learnedPreferences` (local storage, 500-char cap)
- Memory is self-compacting: when the cap is exceeded, a second AI call summarizes all rules to fit within budget
- Local-only users (Gemini Nano) get raw rejection snapshots injected as negative examples instead (no distillation call)
- Learned preferences are shown read-only in the settings page with a Clear button
- Removed the previous profile/feedback-form system entirely

## Test plan

- [ ] Build passes: `npm run build`
- [ ] All 268 tests pass: `npm run test`
- [ ] Dismiss a suggestion → check `chrome.storage.session` contains a `pendingRejections` entry
- [ ] Trigger a processing cycle → verify `learnedPreferences` appears in `chrome.storage.local`
- [ ] Open settings page → verify "What the AI has learned" section appears with the rules
- [ ] Click Clear → section disappears, storage cleared
- [ ] Verify no profile editor or feedback form UI remains in settings or suggestion cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)